### PR TITLE
Custom style

### DIFF
--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -219,21 +219,21 @@
         .then(metadata => {
           metadata = metadata.filter(m => m);
 
-          const strokeOptions = {
-            color: 'blue', 
-            width: 3
+          const styleOptions = {
+            stroke : {
+              color: 'blue', 
+              width: 3
+            },
+            fill : {
+              color: 'rgba(0, 0, 255, 0.1)'
+            },
+            circle : {
+              radius: 5,
+              color: 'green'
+            }
           }
 
-          const fillOptions = {
-            color: 'rgba(0, 0, 255, 0.1)'
-          }
-
-          const circleOptions = {
-            radius: 5,
-            color: 'green'
-          }
-
-          const style = new DICOMMicroscopyViewer.style.ToolStyle(strokeOptions,  fillOptions, circleOptions)
+          const style = new DICOMMicroscopyViewer.style.ToolStyle(styleOptions)
           const viewer = new DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({client, metadata, style});
 
           const container = document.getElementById("dicomImage");

--- a/examples/events/index.html
+++ b/examples/events/index.html
@@ -31,8 +31,8 @@
     </noscript>
 
     <script src="https://unpkg.com/dicomweb-client"></script>
-    <script src="https://unpkg.com/dicom-microscopy-viewer"></script>
-    <!-- <script src="../../build/dicom-microscopy-viewer.js"></script> -->
+    <!-- <script src="https://unpkg.com/dicom-microscopy-viewer"></script> -->
+    <script src="../../build/dicom-microscopy-viewer.js"></script>
     <script>
 
       const CORE_ACTIONS = {
@@ -218,7 +218,23 @@
         })
         .then(metadata => {
           metadata = metadata.filter(m => m);
-          const viewer = new DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({client,metadata});
+
+          const strokeOptions = {
+            color: 'blue', 
+            width: 3
+          }
+
+          const fillOptions = {
+            color: 'rgba(0, 0, 255, 0.1)'
+          }
+
+          const circleOptions = {
+            radius: 5,
+            color: 'green'
+          }
+
+          const style = new DICOMMicroscopyViewer.style.ToolStyle(strokeOptions,  fillOptions, circleOptions)
+          const viewer = new DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({client, metadata, style});
 
           const container = document.getElementById("dicomImage");
           viewer.render({ container });

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,6 +23,7 @@
         <li><a href="basic/index.html">Rendering a single whole-slide image</a> - The basic usage of the library to view a whole slide image</li>
         <li><a href="events/index.html">Handling viewer events</a> - Use custom viewer events to handle actions</li>
         <li><a href="simple_viewer/index.html">Simple whole-slide image viewer</a> - List and navigate available studies/series</li>
+        <li><a href="styling/index.html">Styling example</a> - Customize strokes, text and fill</li>
      </ul>
     <br>
 </div>

--- a/examples/styling/index.html
+++ b/examples/styling/index.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+
+    <title>dicom-microscopy-viewer example</title>
+
+    <!-- Latest compiled and minified CSS -->
+    <link
+      rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+      integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
+      integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0="
+      crossorigin="anonymous"
+    />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jscolor/2.0.4/jscolor.min.js" 
+      integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" 
+      crossorigin="anonymous">
+    </script>
+  </head>
+
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+
+    <script src="https://unpkg.com/dicomweb-client"></script>
+    <!-- <script src="https://unpkg.com/dicom-microscopy-viewer"></script> -->
+    <script src="../../build/dicom-microscopy-viewer.js"></script>
+    <script>
+
+      document.addEventListener("DOMContentLoaded", () => {
+
+        document.getElementById("tools-list").addEventListener("click", (event) => {
+          const geometryType = event.target.id;
+          disableToolList();
+
+          const color = `#${document.getElementById('color').value}`
+
+          const styleOptions = {
+            stroke : {
+              color, 
+              width: 3
+            },
+            fill : {
+              color: 'rgba(0, 0, 255, 0.1)'
+            },
+            circle : {
+              radius: 5,
+              color: 'green'
+            }
+          }
+
+          const style = new DICOMMicroscopyViewer.style.ToolStyle(styleOptions)
+
+          window.viewer.activateDrawInteraction({ geometryType, style });
+          document.getElementById(`${geometryType}`).setAttribute("class", "list-group-item active");          
+        });
+
+      });
+
+      function disableToolList(){
+        const toolList = document.getElementById("tools-list").querySelector("a.active")
+        if(toolList !== null){
+          toolList.classList.remove("active");
+        }
+      }
+
+      const url = "https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs";
+      const client = new DICOMwebClient.api.DICOMwebClient({ url });
+      const studyInstanceUID = "1.2.392.200140.2.1.1.1.2.799008771.2448.1519719572.518";
+      const seriesInstanceUID = "1.2.392.200140.2.1.1.1.3.799008771.2448.1519719572.519";
+
+      const searchInstanceOptions = {
+        studyInstanceUID,
+        seriesInstanceUID
+      };
+
+      client.searchForInstances(searchInstanceOptions)
+        .then(instances => {
+          const promises = [];
+
+          for (let i = 0; i < instances.length; i++) {
+
+            const sopInstanceUID = instances[i]["00080018"]["Value"][0];
+
+            const retrieveInstanceOptions = {
+              studyInstanceUID,
+              seriesInstanceUID,
+              sopInstanceUID
+            };
+
+            const promise = client.retrieveInstanceMetadata(retrieveInstanceOptions)
+              .then(metadata => {
+                const imageType = metadata[0]["00080008"]["Value"];
+                if (imageType[2] === "VOLUME") {
+                  return metadata[0];
+                }
+              });
+            promises.push(promise);
+          }
+          return Promise.all(promises);
+        })
+        .then(metadata => {
+          metadata = metadata.filter(m => m);
+
+          const styleOptions = {
+            stroke : {
+              color: 'blue', 
+              width: 3
+            },
+            fill : {
+              color: 'rgba(0, 0, 255, 0.1)'
+            },
+            circle : {
+              radius: 5,
+              color: 'green'
+            }
+          }
+
+          const style = new DICOMMicroscopyViewer.style.ToolStyle(styleOptions)
+          const viewer = new DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({client, metadata, style});
+
+          const container = document.getElementById("dicomImage");
+          viewer.render({ container });
+
+          viewer.activateDrawInteraction({ geometryType: "polygon" });
+          window.viewer = viewer;
+
+        });
+
+    </script>
+  </body>
+  <body>
+    <div class="container">
+      <div class="page-header">
+        <h1>
+          Microscopy viewer Style Customization
+        </h1>
+        <p>
+          This example demonstrates how to customize the styling with Microscopy viewer.
+        </p>
+        <a href="../">Go back to the Examples page</a>
+      </div>
+
+      <div class="bs-example" data-example-id="simple-thumbnails">
+        <div class="row">
+          <div class="col-xs-6 col-md-4" >
+              <div class="alert alert-warning text-center" role="alert">First, select styling options</div>
+              Color: <input class="jscolor" id="color" value="ab2567">
+          </div>
+          <div class="col-xs-6 col-md-4" >
+            <div class="alert alert-warning text-center" role="alert">Then, Select the tool to use for drawing</div>
+            <div class="list-group" id="tools-list">
+              <a id="polygon" class="list-group-item active">Polygon</a>
+              <a id="point" class="list-group-item">Point</a>
+              <a id="circle" class="list-group-item">Circle</a>
+              <a id="box" class="list-group-item">Box</a>
+              <a id="freehandpolygon" class="list-group-item">Freehand Polygon</a>
+              <a id="line" class="list-group-item">Line</a>
+              <a id="freehandline" class="list-group-item">Freehand Line</a>
+            </div>
+            <br/>
+          </div>          
+          
+          <div class="col-xs-12 col-md-12">
+            <div
+              style="width:100%;height:550px;position:relative;display:inline-block;"
+              oncontextmenu="return false"
+              class="cornerstone-enabled-image"
+              unselectable="on"
+              onselectstart="return false;"
+              onmousedown="return false;"
+            >
+              <div
+                id="dicomImage"
+                style="width:100%;height:550px;top:0px;left:0px; position:absolute; border: 1px solid black;"
+              ></div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <style>
+    .scrollable {
+      height: 600px;
+      overflow-y: scroll;
+    }
+    #rois li {
+      list-style-type: none;
+    }
+    </style>
+  </body>
+</html>

--- a/examples/styling/index.html
+++ b/examples/styling/index.html
@@ -28,6 +28,7 @@
       integrity="sha256-CJWfUCeP3jLdUMVNUll6yQx37gh9AKmXTRxvRf7jzro=" 
       crossorigin="anonymous">
     </script>
+    
   </head>
 
   <body>
@@ -43,102 +44,117 @@
       document.addEventListener("DOMContentLoaded", () => {
 
         document.getElementById("tools-list").addEventListener("click", (event) => {
-          const geometryType = event.target.id;
-          disableToolList();
+          const geometryType = event.target.id
+          disableToolList()
 
-          const color = `#${document.getElementById('color').value}`
+          const style = new DICOMMicroscopyViewer.style.ToolStyle(getStyle())
 
-          const styleOptions = {
-            stroke : {
-              color, 
-              width: 3
-            },
-            fill : {
-              color: 'rgba(0, 0, 255, 0.1)'
-            },
-            circle : {
-              radius: 5,
-              color: 'green'
-            }
+          window.viewer.activateDrawInteraction({ geometryType, style })
+          document.getElementById(`${geometryType}`).setAttribute("class", "list-group-item active")          
+        })
+
+        const elements = ["stroke", "width", "fill_color", "point_color", "point_radius", "text"]
+                            .map(document.getElementById, document)
+
+        elements.forEach(e => {
+          e.addEventListener("change", (event) => {
+            const style = new DICOMMicroscopyViewer.style.ToolStyle(getStyle())
+            const geometryType = document.getElementById("tools-list").querySelector("a.active").id
+            window.viewer.activateDrawInteraction({ geometryType, style })
+          })
+        })
+
+      })
+
+      function getStyle(){
+        const styleOptions = {
+          stroke : {
+            color: `#${document.getElementById('stroke').value}`, 
+            width: document.getElementById('width').value
+          },
+          fill : {
+            color: `${hexToRgbA(document.getElementById('fill_color').value)}`
+          },
+          circle : {
+            radius: `${document.getElementById('point_radius').value}`,
+            color: `#${document.getElementById('point_color').value}`
+          },
+          text : {
+            text : `${document.getElementById('text').value}`
           }
+        }
 
-          const style = new DICOMMicroscopyViewer.style.ToolStyle(styleOptions)
-
-          window.viewer.activateDrawInteraction({ geometryType, style });
-          document.getElementById(`${geometryType}`).setAttribute("class", "list-group-item active");          
-        });
-
-      });
+        return styleOptions
+      }
 
       function disableToolList(){
         const toolList = document.getElementById("tools-list").querySelector("a.active")
         if(toolList !== null){
-          toolList.classList.remove("active");
+          toolList.classList.remove("active")
         }
       }
 
-      const url = "https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs";
-      const client = new DICOMwebClient.api.DICOMwebClient({ url });
-      const studyInstanceUID = "1.2.392.200140.2.1.1.1.2.799008771.2448.1519719572.518";
-      const seriesInstanceUID = "1.2.392.200140.2.1.1.1.3.799008771.2448.1519719572.519";
+      function hexToRgbA(hex){
+        let c
+        if(/^([A-Fa-f0-9]{3}){1,2}$/.test(hex)){
+            c = hex.substring(1).split('')
+            if(c.length== 3){
+                c= [c[0], c[0], c[1], c[1], c[2], c[2]]
+            }
+            c = '0x'+c.join('')
+            return 'rgba('+[(c>>16)&255, (c>>8)&255, c&255].join(',')+',0.1)'
+        }
+        throw new Error('Bad Hex')
+    }
+
+      const url = "https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs"
+      const client = new DICOMwebClient.api.DICOMwebClient({ url })
+      const studyInstanceUID = "1.2.392.200140.2.1.1.1.2.799008771.2448.1519719572.518"
+      const seriesInstanceUID = "1.2.392.200140.2.1.1.1.3.799008771.2448.1519719572.519"
 
       const searchInstanceOptions = {
         studyInstanceUID,
         seriesInstanceUID
-      };
+      }
 
       client.searchForInstances(searchInstanceOptions)
         .then(instances => {
-          const promises = [];
+          const promises = []
 
           for (let i = 0; i < instances.length; i++) {
 
-            const sopInstanceUID = instances[i]["00080018"]["Value"][0];
+            const sopInstanceUID = instances[i]["00080018"]["Value"][0]
 
             const retrieveInstanceOptions = {
               studyInstanceUID,
               seriesInstanceUID,
               sopInstanceUID
-            };
+            }
 
             const promise = client.retrieveInstanceMetadata(retrieveInstanceOptions)
               .then(metadata => {
-                const imageType = metadata[0]["00080008"]["Value"];
+                const imageType = metadata[0]["00080008"]["Value"]
                 if (imageType[2] === "VOLUME") {
-                  return metadata[0];
+                  return metadata[0]
                 }
-              });
-            promises.push(promise);
+              })
+            promises.push(promise)
           }
-          return Promise.all(promises);
+          return Promise.all(promises)
         })
         .then(metadata => {
-          metadata = metadata.filter(m => m);
+          metadata = metadata.filter(m => m)
 
-          const styleOptions = {
-            stroke : {
-              color: 'blue', 
-              width: 3
-            },
-            fill : {
-              color: 'rgba(0, 0, 255, 0.1)'
-            },
-            circle : {
-              radius: 5,
-              color: 'green'
-            }
-          }
+          const style = new DICOMMicroscopyViewer.style.ToolStyle(getStyle())
+          const viewer = new DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({client, metadata, style})
 
-          const style = new DICOMMicroscopyViewer.style.ToolStyle(styleOptions)
-          const viewer = new DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer({client, metadata, style});
+          const container = document.getElementById("dicomImage")
+          viewer.render({ container })
 
-          const container = document.getElementById("dicomImage");
-          viewer.render({ container });
+          viewer.activateDrawInteraction({ geometryType: "polygon" })
+          window.viewer = viewer
 
-          viewer.activateDrawInteraction({ geometryType: "polygon" });
-          window.viewer = viewer;
-
-        });
+        })
 
     </script>
   </body>
@@ -157,10 +173,57 @@
       <div class="bs-example" data-example-id="simple-thumbnails">
         <div class="row">
           <div class="col-xs-6 col-md-4" >
-              <div class="alert alert-warning text-center" role="alert">First, select styling options</div>
-              Color: <input class="jscolor" id="color" value="ab2567">
+              <div class="alert alert-warning text-center" role="alert">Stroke styling options</div>
+              
+                <div class="form-group row">
+                  <label class="col-sm-2 col-form-label" for="stroke">Stroke</label>
+                  <div class="col-sm-10">
+                    <input class="form-control-plaintext jscolor" id="stroke" value="ab2567">
+                  </div>
+                </div>
+                <div class="form-group row">
+                  <label class="col-sm-2 col-form-label" for="width">Width</label>
+                  <div class="col-sm-10">
+                    <input type="text" class="form-control-plaintext" id="width" value="1">
+                  </div>
+                </div>
+
+                <div class="alert alert-warning text-center" role="alert">Fill</div>
+
+                <div class="form-group row">
+                  <label class="col-sm-2 col-form-label" for="fill_color">Color</label>
+                  <div class="col-sm-10">
+                    <input type="text" class="form-control-plaintext jscolor" id="fill_color" value="CFB2C6">
+                  </div>
+                </div>
           </div>
           <div class="col-xs-6 col-md-4" >
+              <div class="alert alert-warning text-center" role="alert">Point styling options</div>
+
+              <div class="form-group row">
+                <label class="col-sm-2 col-form-label" for="point_color">Color</label>
+                <div class="col-sm-10">
+                  <input type="text" class="form-control-plaintext jscolor" id="point_color" value="0EAB72">
+                </div>
+              </div>
+              <div class="form-group row">
+                <label class="col-sm-2 col-form-label" for="point_radius">Radius</label>
+                <div class="col-sm-10">
+                  <input type="text" class="form-control-plaintext" id="point_radius" value="5">
+                </div>
+              </div>
+
+              <div class="alert alert-warning text-center" role="alert">Text styling options</div>
+
+              <div class="form-group row">
+                <label class="col-sm-2 col-form-label" for="text">Text</label>
+                <div class="col-sm-10">
+                  <input type="text" class="form-control-plaintext" id="text" value="">
+                </div>
+              </div>
+
+          </div>
+          <div class="col-xs-12 col-md-4" >
             <div class="alert alert-warning text-center" role="alert">Then, Select the tool to use for drawing</div>
             <div class="list-group" id="tools-list">
               <a id="polygon" class="list-group-item active">Polygon</a>
@@ -176,16 +239,16 @@
           
           <div class="col-xs-12 col-md-12">
             <div
-              style="width:100%;height:550px;position:relative;display:inline-block;"
+              style="width:100%;height:550px;position:relative;display:inline-block"
               oncontextmenu="return false"
               class="cornerstone-enabled-image"
               unselectable="on"
-              onselectstart="return false;"
-              onmousedown="return false;"
+              onselectstart="return false"
+              onmousedown="return false"
             >
               <div
                 id="dicomImage"
-                style="width:100%;height:550px;top:0px;left:0px; position:absolute; border: 1px solid black;"
+                style="width:100%;height:550px;top:0px;left:0px; position:absolute; border: 1px solid black"
               ></div>
 
             </div>
@@ -196,10 +259,10 @@
     <style>
     .scrollable {
       height: 600px;
-      overflow-y: scroll;
+      overflow-y: scroll
     }
     #rois li {
-      list-style-type: none;
+      list-style-type: none
     }
     </style>
   </body>

--- a/src/api.js
+++ b/src/api.js
@@ -710,7 +710,7 @@ class VLWholeSlideMicroscopyImageViewer {
     const defaultDrawOptions = {source: this[_drawingSource]};
     const customDrawOptions = customOptionsMapping[options.geometryType];
     if ('style' in options) {
-      customDrawOptions.style = options.style;
+      customDrawOptions.style = options.style.getStyle();
     }
     const allDrawOptions = Object.assign(defaultDrawOptions, customDrawOptions);
     this[_interactions].draw = new Draw(allDrawOptions);

--- a/src/api.js
+++ b/src/api.js
@@ -11,6 +11,7 @@ import ScaleLine from 'ol/control/ScaleLine';
 import Draw, {createRegularPolygon, createBox} from 'ol/interaction/Draw';
 import Select from 'ol/interaction/Select';
 import Modify from 'ol/interaction/Modify';
+import MultiPoint from 'ol/geom/MultiPoint.js';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import Collection from 'ol/Collection';
@@ -511,6 +512,12 @@ class VLWholeSlideMicroscopyImageViewer {
       projection: projection
     });
 
+    let styles;
+
+    if(options.style !== undefined){
+      styles = [options.style.getStyle()]
+    }
+
     this[_drawingSource] = new VectorSource({
       tileGrid: tileGrid,
       projection: projection,
@@ -521,6 +528,7 @@ class VLWholeSlideMicroscopyImageViewer {
     this[_drawingLayer] = new VectorLayer({
       extent: extent,
       source: this[_drawingSource],
+      style: styles,
       projection: projection,
       updateWhileAnimating: true,
       updateWhileInteracting: true,

--- a/src/api.js
+++ b/src/api.js
@@ -514,7 +514,7 @@ class VLWholeSlideMicroscopyImageViewer {
 
     let styles;
 
-    if(options.style !== undefined){
+    if('style' in options){
       styles = [options.style.getStyle()]
     }
 
@@ -709,11 +709,14 @@ class VLWholeSlideMicroscopyImageViewer {
 
     const defaultDrawOptions = {source: this[_drawingSource]};
     const customDrawOptions = customOptionsMapping[options.geometryType];
-    if ('style' in options) {
-      customDrawOptions.style = options.style.getStyle();
-    }
     const allDrawOptions = Object.assign(defaultDrawOptions, customDrawOptions);
     this[_interactions].draw = new Draw(allDrawOptions);
+    
+    if ('style' in options) {
+      this[_interactions].draw.on('drawstart',function(event){
+        event.feature.setStyle(options.style.getStyle());    
+      });
+    }
 
     const container = this[_map].getTargetElement();
 

--- a/src/dicom-microscopy-viewer.js
+++ b/src/dicom-microscopy-viewer.js
@@ -1,5 +1,6 @@
 import { VLWholeSlideMicroscopyImageViewer } from './api.js';
 import { ROI } from './roi.js';
+import { ToolStyle } from './style.js'
 import {
   Point,
   Multipoint,
@@ -24,4 +25,8 @@ let roi = {
   ROI,
 }
 
-export { api, scoord3d, roi };
+let style = {
+  ToolStyle
+}
+
+export { api, scoord3d, roi, style };

--- a/src/scoord3d.js
+++ b/src/scoord3d.js
@@ -5,8 +5,6 @@
 const _coordinates = Symbol('coordinates')
 const _majorAxisEndpointCoordinates = Symbol('majorAxisEndpointCoordinates')
 const _minorAxisEndpointCoordinates = Symbol('minorAxisEndpointCoordinates')
-const _centerCoordinates = Symbol('centerCoordinates')
-const _radius = Symbol('radius')
 
 class Scoord3D {
 

--- a/src/style.js
+++ b/src/style.js
@@ -1,25 +1,37 @@
-import {Fill, Stroke, Style as OpenLayersStyle, Circle as CircleStyle} from 'ol/style.js';
+import {Fill, Stroke, Text, Style as OpenLayersStyle, Circle as CircleStyle} from 'ol/style.js';
 
 const _style = Symbol('style')
 
 class ToolStyle {  
   
-    constructor(strokeOptions, fillOptions, circleOptions, textOptions) {
+    constructor(styleOptions) {
 
       const style = new OpenLayersStyle({
         stroke: new Stroke({
-          color: strokeOptions.color,
-          width: strokeOptions.width
+          color: styleOptions.stroke.color !== undefined ? styleOptions.stroke.color : 'green',
+          width: styleOptions.stroke.width !== undefined ? styleOptions.stroke.width : 1
         }),
         fill: new Fill({
-          color: fillOptions.color
+          color: styleOptions.fill.color !== undefined ? styleOptions.fill.color : 'rgba(0, 255, 0, 0.1)'
         }),
         image: new CircleStyle({
-          radius: circleOptions.radius,
+          radius: styleOptions.circle.radius !== undefined ? styleOptions.circle.radius : 5,
           fill: new Fill({
-            color: circleOptions.color
+            color: styleOptions.circle.color !== undefined ? styleOptions.circle.color : 'green'
           })
-        })
+        }),
+        text : styleOptions.text !== undefined ? new Text({
+          font: '10px sans-serif',
+          textAlign : 'center',  
+          text : 'teste',
+          offsetX : 0,
+          offsetY : 0,
+          scale : 1,
+          textBaseline : 'center',
+          fill : new Fill({
+            color: '#333'
+          })
+        }) : new Text()
       })
 
       this[_style] = style

--- a/src/style.js
+++ b/src/style.js
@@ -23,7 +23,7 @@ class ToolStyle {
         text : styleOptions.text !== undefined ? new Text({
           font: styleOptions.text.font !== undefined ? styleOptions.text.font : '10px sans-serif',
           textAlign : styleOptions.text.textAlign !== undefined ? styleOptions.text.textAlign : 'center',  
-          text : styleOptions.text.text !== undefined ? styleOptions.text.text : 'teste',
+          text : styleOptions.text.text !== undefined ? styleOptions.text.text : '',
           offsetX : styleOptions.text.offsetX !== undefined ? styleOptions.text.offsetX : 0,
           offsetY : styleOptions.text.offsetY !== undefined ? styleOptions.text.offsetY : 0,
           scale : styleOptions.text.scale !== undefined ? styleOptions.text.scale : 1,

--- a/src/style.js
+++ b/src/style.js
@@ -1,0 +1,35 @@
+import {Fill, Stroke, Style as OpenLayersStyle, Circle as CircleStyle} from 'ol/style.js';
+
+const _style = Symbol('style')
+
+class ToolStyle {  
+  
+    constructor(strokeOptions, fillOptions, circleOptions, textOptions) {
+
+      const style = new OpenLayersStyle({
+        stroke: new Stroke({
+          color: strokeOptions.color,
+          width: strokeOptions.width
+        }),
+        fill: new Fill({
+          color: fillOptions.color
+        }),
+        image: new CircleStyle({
+          radius: circleOptions.radius,
+          fill: new Fill({
+            color: circleOptions.color
+          })
+        })
+      })
+
+      this[_style] = style
+
+    }
+
+    getStyle(){
+      return this[_style]
+    }
+  
+  }
+
+export { ToolStyle };

--- a/src/style.js
+++ b/src/style.js
@@ -21,15 +21,15 @@ class ToolStyle {
           })
         }),
         text : styleOptions.text !== undefined ? new Text({
-          font: '10px sans-serif',
-          textAlign : 'center',  
-          text : 'teste',
-          offsetX : 0,
-          offsetY : 0,
-          scale : 1,
-          textBaseline : 'center',
+          font: styleOptions.text.font !== undefined ? styleOptions.text.font : '10px sans-serif',
+          textAlign : styleOptions.text.textAlign !== undefined ? styleOptions.text.textAlign : 'center',  
+          text : styleOptions.text.text !== undefined ? styleOptions.text.text : 'teste',
+          offsetX : styleOptions.text.offsetX !== undefined ? styleOptions.text.offsetX : 0,
+          offsetY : styleOptions.text.offsetY !== undefined ? styleOptions.text.offsetY : 0,
+          scale : styleOptions.text.scale !== undefined ? styleOptions.text.scale : 1,
+          textBaseline : styleOptions.text.textBaseline !== undefined ? styleOptions.text.textBaseline : 'center',
           fill : new Fill({
-            color: '#333'
+            color: styleOptions.text.fillColor !== undefined ? styleOptions.text.fillColor : '#333'
           })
         }) : new Text()
       })


### PR DESCRIPTION
### What
There is an open issue to create enable users to customize the style of controls and annotations.
This PR is covering an abstraction layer through OpenLayers so that users can use Microscopy Styling without touching OpenLayers directly.
https://github.com/dcmjs-org/dicom-microscopy-viewer/blob/custom-style/src/style.js

This PR is not covering the feature to allow users to change some of the styles via CSS, for example, color or line thickness of selected or modified ROIs. I would recommend open a new PR latter only for this part.


![style_comp](https://user-images.githubusercontent.com/1713255/55663760-1dcda380-57f9-11e9-9f8b-7ce2cc08f596.gif)



There is a live example at https://custom-style--dicom-microscopy-viewer.netlify.com/styling/index.html

### Why

We want to allow an application to customize styling, such that the style of library elements can be matched to that of the application.

