### PR TITLE
Move the octetStreamTransferSyntaxUID as the first media

### DIFF
--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -436,6 +436,10 @@ function _createTileLoadFunction ({
       const mediaTypes = []
       mediaTypes.push(...[
         {
+          mediaType: octetStreamMediaType,
+          transferSyntaxUID: octetStreamTransferSyntaxUID
+        },
+        {
           mediaType: jlsMediaType,
           transferSyntaxUID: jlsTransferSyntaxUIDlossless
         },
@@ -458,10 +462,6 @@ function _createTileLoadFunction ({
         {
           mediaType: jpxMediaType,
           transferSyntaxUID: jpxTransferSyntaxUID
-        },
-        {
-          mediaType: octetStreamMediaType,
-          transferSyntaxUID: octetStreamTransferSyntaxUID
         }
       ])
       if (bitsAllocated <= 8) {


### PR DESCRIPTION
Moved the application/octet-stream transferSyntaxUID:*  media type first which is more performant than other options if they require transcoding