### PR TITLE
Address annotation issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The library is intended to provide a lightweight and standard-compliant viewer for microscopy images in DICOM format.
 
-The viewer relies on [Openlayers](http://openlayers.org/) for rendering pyramid images and dynamically retrieves pyramid tiles (image frames) via [DICOMweb WADO-RS](https://www.dicomstandard.org/dicomweb/retrieve-wado-rs-and-wado-uri/) using [dicomweb-client](https://github.com/herrmannlab/dicomweb-client).
+The viewer relies on [Openlayers](http://openlayers.org/) for rendering pyramid images and dynamically retrieves pyramid tiles (image frames) via [DICOMweb WADO-RS](https://www.dicomstandard.org/dicomweb/retrieve-wado-rs-and-wado-uri/) using [dicomweb-client](https://github.com/dcmjs-org/dicomweb-client).
 However, the viewer API fully abstracts the underlying rendering library and doesn't expose the lower level Openlayers API directly, such that another rendering library could in principle be used in the future if this would be of advantage.
 
 A central design choice was to not expose any Openlayers objects or functions via the public API, but always provide an abstraction layer.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/herrmannlab/dicom-microscopy-viewer/actions/workflows/run_unit_tests.yml/badge.svg)](https://github.com/herrmannlab/dicom-microscopy-viewer/actions)
+[![Build Status](https://github.com/imagingdatacommons/dicom-microscopy-viewer/actions/workflows/run_unit_tests.yml/badge.svg)](https://github.com/imagingdatacommons/dicom-microscopy-viewer/actions)
 [![NPM version](https://badge.fury.io/js/dicom-microscopy-viewer.svg)](http://badge.fury.io/js/dicom-microscopy-viewer)
 ![NPM downloads per month](https://img.shields.io/npm/dm/dicom-microscopy-viewer?color=blue)
 
@@ -114,7 +114,7 @@ We use [Babel](https://babeljs.io/) to compile (transpile), [webpack](https://we
 Get the source code by cloning the git repository:
 
 ```None
-git clone https://github.com/herrmannlab/dicom-microscopy-viewer
+git clone https://github.com/imagingdatacommons/dicom-microscopy-viewer
 cd dicom-microscopy-viewer
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,23 @@
 {
   "name": "dicom-microscopy-viewer",
-  "version": "0.45.0",
+  "version": "0.45.0",  
+  "license": "MIT",
+  "author": "ImagingDataCommons",
+  "homepage": "https://github.com/imagingdatacommons/dicom-microscopy-viewer#readme",
   "description": "Interactive web-based viewer for DICOM Microscopy Images",
+  "bugs": {
+    "url": "https://github.com/imagingdatacommons/dicom-microscopy-viewer/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/imagingdatacommons/dicom-microscopy-viewer.git"
+  },
+  "keywords": [
+    "dicom",
+    "dcmjs",
+    "dicomweb",
+    "microscopy"
+  ],
   "main": "./src/dicom-microscopy-viewer.js",
   "standard": {
     "ignore": [
@@ -33,22 +49,6 @@
     "webpack:dynamic-import:watch": "webpack --progress --watch --config ./config/webpack/webpack-dynamic-import",
     "webpack:watch": "webpack --progress --watch  --config ./config/webpack"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/herrmannlab/dicom-microscopy-viewer.git"
-  },
-  "keywords": [
-    "dicom",
-    "dcmjs",
-    "dicomweb",
-    "microscopy"
-  ],
-  "author": "Markus D. Herrmann",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/herrmannlab/dicom-microscopy-viewer/issues"
-  },
-  "homepage": "https://github.com/herrmannlab/dicom-microscopy-viewer#readme",
   "devDependencies": {
     "@babel/core": "^7.17",
     "@babel/plugin-proposal-object-rest-spread": "^7.14.7",

--- a/src/annotations/markups/measurement.js
+++ b/src/annotations/markups/measurement.js
@@ -65,27 +65,20 @@ const MeasurementMarkup = ({ map, pyramid, affine, markupManager }) => {
       }
     },
     onRemove: (feature) => {
-      if (_isMeasurement(feature)) {
-        const featureId = feature.getId()
-        markupManager.remove(featureId)
-      }
+      const featureId = feature.getId()
+      markupManager.remove(featureId)
     },
     onDrawStart: ({ feature }) => {
       if (_isMeasurement(feature)) {
-        markupManager.create({ feature })
+        const view = map.getView()
+        const unitSuffix = _getUnitSuffix(view)
+        markupManager.create({
+          feature,
+          value: _format(feature, unitSuffix, pyramid, affine)
+        })
       }
     },
-    onUpdate: (feature) => {
-      const view = map.getView()
-      const unitSuffix = _getUnitSuffix(view)
-      const id = feature.getId()
-      const markup = markupManager.get(id)
-      markupManager.update({
-        feature,
-        value: _format(feature, unitSuffix, pyramid, affine),
-        coordinate: markup.overlay.getPosition()
-      })
-    },
+    onUpdate: (feature) => {},
     onDrawEnd: ({ feature }) => {},
     onDrawAbort: ({ feature }) => {}
   }

--- a/src/enums.js
+++ b/src/enums.js
@@ -18,6 +18,7 @@ export const Markup = {
 
 export const FeatureEvents = {
   CHANGE: 'change',
+  GEOMETRY_CHANGE: 'change:geometry',
   PROPERTY_CHANGE: 'propertychange'
 }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -422,13 +422,11 @@ function _updateFeatureMeasurements (map, feature, pyramid, affine) {
         schemeDesignator: 'SCT'
       }),
       value: area,
-      unit: [
-        new dcmjs.sr.coding.CodedConcept({
-          value: unitCodedConceptValue,
-          meaning: unitCodedConceptMeaning,
-          schemeDesignator: 'SCT'
-        })
-      ]
+      unit: new dcmjs.sr.coding.CodedConcept({
+        value: unitCodedConceptValue,
+        meaning: unitCodedConceptMeaning,
+        schemeDesignator: 'SCT'
+      })
     })
   }
 
@@ -442,13 +440,11 @@ function _updateFeatureMeasurements (map, feature, pyramid, affine) {
         schemeDesignator: 'SCT'
       }),
       value: length,
-      unit: [
-        new dcmjs.sr.coding.CodedConcept({
-          value: unitCodedConceptValue,
-          meaning: unitCodedConceptMeaning,
-          schemeDesignator: 'SCT'
-        })
-      ]
+      unit: new dcmjs.sr.coding.CodedConcept({
+        value: unitCodedConceptValue,
+        meaning: unitCodedConceptMeaning,
+        schemeDesignator: 'SCT'
+      })
     })
   }
 
@@ -1902,6 +1898,9 @@ class VolumeImageViewer {
       )
       _getIccProfiles(metadata, client).then(profiles => {
         const source = item.layer.getSource()
+        if (!source) {
+          return
+        }
         const loader = _createTileLoadFunction({
           targetElement: container,
           iccProfiles: profiles,
@@ -2972,6 +2971,7 @@ class VolumeImageViewer {
 
     if (feature) {
       this[_features].remove(feature)
+      this[_annotationManager].onRemove(feature)
       return
     }
 


### PR DESCRIPTION
- When drawing measurements the first click was dragging the viewport instead of starting the drawing 
- When modifying the geometry the label and linked line was not having its coordinates updated (moving the label the annotation was anchored to the old geometry shape before it was modified)
- Addressed console errors caused by accessing optional values
- Update unit from array to codedConcept to avoid dcmjs errors