### PR TITLE
Added new property to allow change default resolutions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,6 @@ module.exports = {
     '@cornerstonejs/codec-charls/decodewasmjs': '@cornerstonejs/codec-charls/dist/charlswasm_decode.js',
     '@cornerstonejs/codec-charls/decodewasm': '@cornerstonejs/codec-charls/dist/charlswasm_decode.wasm',
     '@cornerstonejs/codec-openjpeg/decodewasmjs': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.js',
-    '@cornerstonejs/codec-openjpeg/decodewasm': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.wasm'
-  }
+    '@cornerstonejs/codec-openjpeg/decodewasm': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.wasm',
+  },
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,6 @@ module.exports = {
     '@cornerstonejs/codec-charls/decodewasmjs': '@cornerstonejs/codec-charls/dist/charlswasm_decode.js',
     '@cornerstonejs/codec-charls/decodewasm': '@cornerstonejs/codec-charls/dist/charlswasm_decode.wasm',
     '@cornerstonejs/codec-openjpeg/decodewasmjs': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.js',
-    '@cornerstonejs/codec-openjpeg/decodewasm': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.wasm',
-  },
+    '@cornerstonejs/codec-openjpeg/decodewasm': '@cornerstonejs/codec-openjpeg/dist/openjpegwasm_decode.wasm'
+  }
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -39,6 +39,7 @@ import { ZoomSlider, Zoom } from 'ol/control'
 import { getCenter, getHeight, getWidth } from 'ol/extent'
 import { defaults as defaultInteractions } from 'ol/interaction'
 import dcmjs from 'dcmjs'
+import _ from 'lodash'
 
 import {
   AnnotationGroup,
@@ -970,7 +971,7 @@ class VolumeImageViewer {
 
     let mapViewResolutions = this[_tileGrid].getResolutions()
 
-    if (Object.hasOwn(this[_options], 'mapViewResolutions')) {
+    if (_.has(this[_options], 'mapViewResolutions')) {
       mapViewResolutions = this[_options].mapViewResolutions
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -799,7 +799,7 @@ class VolumeImageViewer {
     if (this[_options].highlightColor == null) {
       this[_options].highlightColor = [140, 184, 198]
     }
-    
+
     // Collection of Openlayers "TileLayer" instances
     this[_segments] = {}
     this[_mappings] = {}
@@ -968,9 +968,9 @@ class VolumeImageViewer {
       tileSizes: this[_pyramid].tileSizes
     })
 
-    let mapViewResolutions = this[_tileGrid].getResolutions();
-    
-    if (this[_options].hasOwnProperty('mapViewResolutions')) {
+    let mapViewResolutions = this[_tileGrid].getResolutions()
+
+    if (Object.hasOwn(this[_options], 'mapViewResolutions')) {
       mapViewResolutions = this[_options].mapViewResolutions
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -796,7 +796,6 @@ class VolumeImageViewer {
     if (this[_options].primaryColor == null) {
       this[_options].primaryColor = [0, 126, 163]
     }
-
     if (this[_options].highlightColor == null) {
       this[_options].highlightColor = [140, 184, 198]
     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -745,6 +745,8 @@ class VolumeImageViewer {
    * the application
    * @param {number[]} [options.highlightColor=[140, 184, 198]] - Color that
    * should be used to highlight things that get selected by the user
+   * @param {number[]} [options.mapViewResolutions] Map's view list of
+   * resolutions. If not passed, the tile grid resolution will be used.
    */
   constructor (options) {
     this[_options] = options
@@ -793,10 +795,11 @@ class VolumeImageViewer {
     if (this[_options].primaryColor == null) {
       this[_options].primaryColor = [0, 126, 163]
     }
+
     if (this[_options].highlightColor == null) {
       this[_options].highlightColor = [140, 184, 198]
     }
-
+    
     // Collection of Openlayers "TileLayer" instances
     this[_segments] = {}
     this[_mappings] = {}
@@ -965,10 +968,16 @@ class VolumeImageViewer {
       tileSizes: this[_pyramid].tileSizes
     })
 
+    let mapViewResolutions = this[_tileGrid].getResolutions();
+    
+    if (this[_options].hasOwnProperty('mapViewResolutions')) {
+      mapViewResolutions = this[_options].mapViewResolutions
+    }
+
     const view = new View({
       center: getCenter(this[_pyramid].extent),
       projection: this[_projection],
-      resolutions: this[_tileGrid].getResolutions(),
+      resolutions: mapViewResolutions,
       rotation: this[_rotation],
       constrainOnlyCenter: false,
       smoothResolutionConstraint: true,


### PR DESCRIPTION
This change was created on a client request to enable the viewer to show the entire image when is displaying on small screens. Without this change, the Zoom doesn't allow the user to completely out of the image.

With this change allowed, this will be the behavior:
![image](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/assets/115191433/37cb0204-48be-4840-aa50-0290d97dcb63)


Without this change, this is the actually behavior:
![image](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/assets/115191433/1b84a821-44c3-4e63-ade7-981cdebaca9b)
