### PR TITLE
fix(viewer.js): Avoid double click for draw interaction

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1373,6 +1373,10 @@ class VolumeImageViewer {
 
     let clickEvent = null
     this[_map].on('dblclick', (event) => {
+      if (this[_interactions].draw !== undefined) {
+        return
+      }
+
       clickEvent = 'dblclick'
       this[_map].forEachFeatureAtPixel(
         event.pixel,


### PR DESCRIPTION
- Avoid double click event with draw interaction active to avoid conflicts with the draw events