### PR TITLE
add permissions to publish npm packages with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,3 +16,5 @@ jobs:
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_DMV_GRANULAR }}
+permissions:
+  id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
     types: [published]
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,5 +19,3 @@ jobs:
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_DMV_GRANULAR }}
-permissions:
-  id-token: write


### PR DESCRIPTION
for the reference see https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions