### PR TITLE
fix: remove segmentation background

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4283,6 +4283,7 @@ class VolumeImageViewer {
 
       const defaultSegmentStyle = {
         opacity: 0.75,
+        backgroundOpacity: 0,
         paletteColorLookupTable: buildPaletteColorLookupTable({
           data: colormap,
           firstValueMapped: 0
@@ -4342,13 +4343,16 @@ class VolumeImageViewer {
         source,
         extent: this[_pyramid].extent,
         visible: false,
-        opacity: 0.9,
+        opacity: 1,
         preload: this[_options].preload ? 1 : 0,
         transition: 0,
         style: _getColorPaletteStyleForTileLayer({
           windowCenter,
           windowWidth,
-          colormap: segment.style.paletteColorLookupTable.data
+          colormap: [
+            [...segment.style.paletteColorLookupTable.data.at(0), defaultSegmentStyle.backgroundOpacity],
+            [...segment.style.paletteColorLookupTable.data.at(-1)],
+          ],
         }),
         useInterimTilesOnError: false,
         cacheSize: this[_options].tilesCacheSize,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4351,8 +4351,8 @@ class VolumeImageViewer {
           windowWidth,
           colormap: [
             [...segment.style.paletteColorLookupTable.data.at(0), defaultSegmentStyle.backgroundOpacity],
-            [...segment.style.paletteColorLookupTable.data.at(-1)],
-          ],
+            [...segment.style.paletteColorLookupTable.data.at(-1)]
+          ]
         }),
         useInterimTilesOnError: false,
         cacheSize: this[_options].tilesCacheSize,


### PR DESCRIPTION
Addresses: https://github.com/ImagingDataCommons/slim/issues/245

Removes the background color of the segmentations. Use the following dataset to test with slim:

`https://healthcare.googleapis.com/v1/projects/idc-sandbox-000/locations/us-central1/datasets/fedorov-dev-healthcare/dicomStores/singlebitsegstest/dicomWeb`