### PR TITLE
Add ie support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,17 @@
 module.exports = {
-  presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+  presets: [
+    ['@babel/preset-env', {
+      targets: {
+        browsers: ['ie 11']
+      }
+    }]
+  ],
   plugins: [
-    ['@babel/plugin-proposal-object-rest-spread'],
     ['@babel/plugin-transform-runtime',
       {
         regenerator: true,
         corejs: 3
-      }]
+      }
+    ]
   ]
 }


### PR DESCRIPTION
# Update Babel configuration for IE 11 compatibility

-Request: Target IE 11 #35

## Description
Updates the Babel configuration to align with other dcmjs-org libraries by providing an IE 11 compatible build out of the box. This change will make the package easier to use as a dependency since consumers targeting IE 11 won't need to transpile this dependency on every build.

## Changes
- Removed `node: 'current'` target as it's not necessary (Jest tests work fine without it)
- Removed redundant `@babel/plugin-proposal-object-rest-spread` plugin since it's included in `@babel/preset-env` by default
- Simplified configuration to target IE 11 browsers, matching the approach used in other dcmjs-org repositories

## Notes
- This configuration ensures compatibility with IE 11 while maintaining support for all modern browsers
- The simplified configuration follows the pattern established in other dcmjs-org libraries (e.g., dcmjs)
- No functional changes to the codebase, only build configuration updates

## Related
Follows the pattern from: https://github.com/dcmjs-org/dcmjs/blob/master/.babelrc