### PR TITLE
fix: fractional segmentation

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4486,7 +4486,7 @@ class VolumeImageViewer {
    *
    * @param {Object} segment - The segment for which to show the overlay
    */
-  addOverlay (segment) {
+  addSegmentOverlay (segment) {
     let title = segment.segment.propertyType.CodeMeaning
     const padding = Math.round((16 - title.length) / 2)
     title = title.padStart(title.length + padding)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4524,11 +4524,11 @@ class VolumeImageViewer {
       context.fillRect(0, height / colors.length * j, width, 1)
     }
 
-    const upperBound = document.createElement('span');
-    upperBound.innerHTML = '255';
+    const upperBound = document.createElement('span')
+    upperBound.innerHTML = '255'
 
-    const lowerBound = document.createElement('span');
-    lowerBound.innerHTML = '0';
+    const lowerBound = document.createElement('span')
+    lowerBound.innerHTML = '0'
 
     overlayElement.appendChild(upperBound)
     overlayElement.appendChild(canvas)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4486,7 +4486,7 @@ class VolumeImageViewer {
    *
    * @param {Object} segment - The segment for which to show the overlay
    */
-  addOverlay(segment) {
+  addOverlay (segment) {
     let title = segment.segment.propertyType.CodeMeaning
     const padding = Math.round((16 - title.length) / 2)
     title = title.padStart(title.length + padding)
@@ -4554,8 +4554,8 @@ class VolumeImageViewer {
       segment.layer.setOpacity(styleOptions.opacity)
     }
 
-    if(segment.segmentationType === 'FRACTIONAL'){
-      this.addOverlay(segment);
+    if (segment.segmentationType === 'FRACTIONAL') {
+      this.addOverlay(segment)
     }
   }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -142,6 +142,9 @@ function disposeOverviewMapLayers (map) {
  */
 export function disposeLayer (layer, disposeSource = false) {
   console.info('dispose layer:', layer)
+  if(typeof layer?.getSource !== 'function'){
+    return;
+  }
   const source = layer.getSource()
   if (disposeSource === true && source && source.clear) {
     source.clear()

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -142,8 +142,8 @@ function disposeOverviewMapLayers (map) {
  */
 export function disposeLayer (layer, disposeSource = false) {
   console.info('dispose layer:', layer)
-  if(typeof layer?.getSource !== 'function'){
-    return;
+  if (typeof layer?.getSource !== 'function') {
+    return
   }
   const source = layer.getSource()
   if (disposeSource === true && source && source.clear) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4420,7 +4420,7 @@ class VolumeImageViewer {
    * @param {Object} [styleOptions]
    * @param {number} [styleOptions.opacity] - Opacity
    */
-  showSegment (segmentUID, styleOptions = {}) {
+  showSegment (segmentUID, styleOptions = {}, shouldZoomIn = false) {
     if (!(segmentUID in this[_segments])) {
       const error = new CustomError(
         errorTypes.VISUALIZATION,
@@ -4440,6 +4440,18 @@ class VolumeImageViewer {
       })
       const source = segment.layer.getSource()
       source.setLoader(loader)
+    }
+
+    if (shouldZoomIn) {
+      const view = this[_map].getView()
+      const currentZoomLevel = view.getZoom()
+
+      if (
+        currentZoomLevel < segment.minZoomLevel ||
+        currentZoomLevel > segment.maxZoomLevel
+      ) {
+        view.animate({ zoom: segment.minZoomLevel })
+      }
     }
 
     segment.layer.setVisible(true)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4564,7 +4564,7 @@ class VolumeImageViewer {
     }
 
     if (segment.segmentationType === 'FRACTIONAL') {
-      this.addOverlay(segment)
+      this.addSegmentOverlay(segment)
     }
   }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4523,7 +4523,16 @@ class VolumeImageViewer {
       context.fillStyle = `rgb(${r}, ${g}, ${b})`
       context.fillRect(0, height / colors.length * j, width, 1)
     }
+
+    const upperBound = document.createElement('span');
+    upperBound.innerHTML = '255';
+
+    const lowerBound = document.createElement('span');
+    lowerBound.innerHTML = '0';
+
+    overlayElement.appendChild(upperBound)
     overlayElement.appendChild(canvas)
+    overlayElement.appendChild(lowerBound)
 
     const parentElement = overlayElement.parentNode
     parentElement.style.display = 'inline'


### PR DESCRIPTION
Fixing fractional segmentations:
1 - fixing color palette and maintaining transparent background
2 - removing color palette overlay for binary segmentations
3 - removing annoying zoom when activating segmentations

Addresses: https://github.com/ImagingDataCommons/slim/issues/245

Binary segmentation now = no background and no color palette overlay:
![image](https://github.com/user-attachments/assets/33971a67-73fe-4d44-9f91-3ba676df0794)

Fractional segmentation now = no background and proper colors:
![image](https://github.com/user-attachments/assets/2d5641c7-b185-4872-9a78-bf4f2c142bbe)
