### PR TITLE
feat: add viewport clicked event and clear selections method

### DIFF
--- a/src/eventPublisher.js
+++ b/src/eventPublisher.js
@@ -27,7 +27,7 @@ const publish = (el, type, payload = null) => {
     event.initCustomEvent(type, true, true, detail)
   }
 
-  return el.dispatchEvent(event)
+  return el?.dispatchEvent?.(event)
 }
 
 export default publish

--- a/src/events.js
+++ b/src/events.js
@@ -18,6 +18,8 @@ const EVENTS = {
   ROI_DRAWN: `${PROJECT_NAME}_roi_drawn`,
   /** Triggered when a ROI was selected. */
   ROI_SELECTED: `${PROJECT_NAME}_roi_selected`,
+  /** Triggered when the map is clicked but no ROI was selected. */
+  NO_ROI_SELECTED: `${PROJECT_NAME}_no_roi_selected`,
   /** Triggered when a ROI was double clicked. */
   ROI_DOUBLE_CLICKED: `${PROJECT_NAME}_roi_double_clicked`,
   /** Triggered when mouse moves. */

--- a/src/events.js
+++ b/src/events.js
@@ -18,8 +18,8 @@ const EVENTS = {
   ROI_DRAWN: `${PROJECT_NAME}_roi_drawn`,
   /** Triggered when a ROI was selected. */
   ROI_SELECTED: `${PROJECT_NAME}_roi_selected`,
-  /** Triggered when the map is clicked but no ROI was selected. */
-  NO_ROI_SELECTED: `${PROJECT_NAME}_no_roi_selected`,
+  /** Triggered when the map is clicked. */
+  VIEWPORT_CLICKED: `${PROJECT_NAME}_viewport_clicked`,
   /** Triggered when a ROI was double clicked. */
   ROI_DOUBLE_CLICKED: `${PROJECT_NAME}_roi_double_clicked`,
   /** Triggered when mouse moves. */

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1680,10 +1680,16 @@ class VolumeImageViewer {
       }
 
       clickEvent = 'click'
-      const features = this[_map].getFeaturesAtPixel(event.pixel)
+      const features = this[_map].getFeaturesAtPixel(event.pixel);
+      const rois = features.map(feature =>
+        this._getROIFromFeature(
+          feature,
+          this[_pyramid].metadata,
+          this[_affine]
+        ))
 
       publish(this[_map].getTargetElement(), EVENT.VIEWPORT_CLICKED, {
-        featuresAtPixel: features.length
+        rois,
       })
 
       this[_map].forEachFeatureAtPixel(

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2940,6 +2940,11 @@ class VolumeImageViewer {
     }
   }
 
+  clearSelections () {
+    this.deactivateSelectInteraction()
+    this.activateSelectInteraction()
+  }
+
   /**
    * Activate drag pan interaction.
    *

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1682,14 +1682,10 @@ class VolumeImageViewer {
       clickEvent = 'click'
       const features = this[_map].getFeaturesAtPixel(event.pixel)
 
-      if (features.length === 0) {
-        console.info('No feature clicked.')
-        return publish(
-          this[_map].getTargetElement(),
-          EVENT.NO_ROI_SELECTED,
-          null
-        )
-      }
+      publish(this[_map].getTargetElement(), EVENT.VIEWPORT_CLICKED, {
+        featuresAtPixel: features.length,
+      });
+
 
       this[_map].forEachFeatureAtPixel(
         event.pixel,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1683,9 +1683,8 @@ class VolumeImageViewer {
       const features = this[_map].getFeaturesAtPixel(event.pixel)
 
       publish(this[_map].getTargetElement(), EVENT.VIEWPORT_CLICKED, {
-        featuresAtPixel: features.length,
-      });
-
+        featuresAtPixel: features.length
+      })
 
       this[_map].forEachFeatureAtPixel(
         event.pixel,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -3118,11 +3118,8 @@ class VolumeImageViewer {
     console.info(`get ROI ${uid}`)
     const feature = this[_drawingSource].getFeatureById(uid)
     if (feature == null) {
-      const error = new CustomError(
-        errorTypes.VISUALIZATION,
-        `Could not find a ROI with UID "${uid}".`
-      )
-      throw this[_options].errorInterceptor(error)
+      console.warn(`Could not find a ROI with UID "${uid}".`);
+      return;
     }
 
     return this._getROIFromFeature(

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1680,6 +1680,17 @@ class VolumeImageViewer {
       }
 
       clickEvent = 'click'
+      const features = this[_map].getFeaturesAtPixel(event.pixel);
+
+      if(features.length === 0){
+        console.info('No feature clicked.')
+        return publish(
+          this[_map].getTargetElement(),
+          EVENT.ROI_SELECTED,
+          null,
+        )
+      }
+
       this[_map].forEachFeatureAtPixel(
         event.pixel,
         (feature) => {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1680,14 +1680,14 @@ class VolumeImageViewer {
       }
 
       clickEvent = 'click'
-      const features = this[_map].getFeaturesAtPixel(event.pixel);
+      const features = this[_map].getFeaturesAtPixel(event.pixel)
 
-      if(features.length === 0){
+      if (features.length === 0) {
         console.info('No feature clicked.')
         return publish(
           this[_map].getTargetElement(),
           EVENT.ROI_SELECTED,
-          null,
+          null
         )
       }
 
@@ -3129,8 +3129,8 @@ class VolumeImageViewer {
     console.info(`get ROI ${uid}`)
     const feature = this[_drawingSource].getFeatureById(uid)
     if (feature == null) {
-      console.warn(`Could not find a ROI with UID "${uid}".`);
-      return;
+      console.warn(`Could not find a ROI with UID "${uid}".`)
+      return
     }
 
     return this._getROIFromFeature(

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1686,7 +1686,7 @@ class VolumeImageViewer {
         console.info('No feature clicked.')
         return publish(
           this[_map].getTargetElement(),
-          EVENT.ROI_SELECTED,
+          EVENT.NO_ROI_SELECTED,
           null
         )
       }
@@ -2940,6 +2940,9 @@ class VolumeImageViewer {
     }
   }
 
+  /**
+   * Clear all selections.
+   */
   clearSelections () {
     this.deactivateSelectInteraction()
     this.activateSelectInteraction()

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1680,7 +1680,7 @@ class VolumeImageViewer {
       }
 
       clickEvent = 'click'
-      const features = this[_map].getFeaturesAtPixel(event.pixel);
+      const features = this[_map].getFeaturesAtPixel(event.pixel)
       const rois = features.map(feature =>
         this._getROIFromFeature(
           feature,
@@ -1689,7 +1689,7 @@ class VolumeImageViewer {
         ))
 
       publish(this[_map].getTargetElement(), EVENT.VIEWPORT_CLICKED, {
-        rois,
+        rois
       })
 
       this[_map].forEachFeatureAtPixel(


### PR DESCRIPTION
## Summary
This PR introduces:

* an event that is published when the viewport is clicked, allowing consumers to:
  * Update their selected features properties.
  * Execute callbacks appropriately.

* a clear selections method to:
  * allow consumers to programatically clear selections instead of relying on user clicks 

This change is necessary for: [slim#196](https://github.com/ImagingDataCommons/slim/issues/196)

## Additional Improvements
* Graceful Handling of Missing ROIs
When attempting to retrieve a ROI that isn't found, it now logs a warning instead of throwing an error or displaying one to the user.

* Safe Access to `el` in the `publish` function
Added optional chaining to handle cases where the `el` variable may be undefined in the published event payload.