### PR TITLE
Remove content label filter for parametric maps

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5084,13 +5084,6 @@ class VolumeImageViewer {
 
     const refImage = this[_pyramid].metadata[0]
     const refParametricMap = metadata[0]
-    if (refParametricMap.ContentLabel !== 'HEATMAP') {
-      console.warn(
-        'skip mappings because value of "Content Label" attribute of ' +
-        'Parametric Map instances is not "HEATMAP"'
-      )
-      return
-    }
 
     metadata.forEach(instance => {
       if (


### PR DESCRIPTION
There is a hard-coded filter on the "ContentLabel" of a parametric map, such that it will not display unless the ContentLabel is exactly "HEATMAP".

This PR simply removes this limitation such that a parametric map should display regardless of its ContentLabel