### PR TITLE
fix: Turn off interpolation for special unmatched resolution seg case

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "dicomicc": "^0.1",
     "image-type": "^4.1",
     "mathjs": "^11.2",
-    "ol": "^10.4.0",
+    "ol": "^10.6.0",
     "uuid": "^9.0"
   },
   "resolutions": {

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -146,7 +146,7 @@ function _computeImagePyramid ({ metadata }) {
       rawMetadata['00280008'].Value[0] += numberOfFrames
       if ('PerFrameFunctionalGroupsSequence' in metadata[index]) {
         rawMetadata['52009230'].Value.push(
-          ...metadata[i].PerFrameFunctionalGroupsSequence
+          ...metadata[index].PerFrameFunctionalGroupsSequence
         )
       }
       if (!('SOPInstanceUIDOfConcatenationSource' in metadata[i])) {
@@ -613,13 +613,14 @@ function _fitImagePyramid (pyramid, refPyramid) {
     console.warn('No matching pyramid levels found, handling fixed pixel spacing case...')
 
     const refBaseLevel = refPyramid.metadata[refPyramid.metadata.length - 1]
-    const refBaseTotalPixelMatrixColumns = refBaseLevel.TotalPixelMatrixColumns
 
     for (let j = 0; j < pyramid.metadata.length; j++) {
-      const imageLevel = pyramid.metadata[j]
-      const totalPixelMatrixColumns = imageLevel.TotalPixelMatrixColumns
+      const segmentation = pyramid.metadata[j]
+      const refBasePixelSpacing = getPixelSpacing(refBaseLevel)
+      const segPixelSpacing = getPixelSpacing(segmentation)
 
-      const resolution = refBaseTotalPixelMatrixColumns / totalPixelMatrixColumns
+      /** Calculate resolution based on ratio of pixel spacings */
+      const resolution = segPixelSpacing[0] / refBasePixelSpacing[0]
       const roundedResolution = Math.round(resolution)
 
       /** Handle resolution conflicts similar to _computeImagePyramid */

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -675,7 +675,9 @@ function _fitImagePyramid (pyramid, refPyramid) {
     }
   }
 
-  return [fittedPyramid, minZoom, maxZoom]
+  const hasMatchingLevels = matchingLevelIndices.length > 0
+
+  return [fittedPyramid, minZoom, maxZoom, hasMatchingLevels]
 }
 
 export {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4637,7 +4637,7 @@ class VolumeImageViewer {
     )
 
     const pyramid = _computeImagePyramid({ metadata })
-    const [fittedPyramid, minZoomLevel, maxZoomLevel] = _fitImagePyramid(
+    const [fittedPyramid, minZoomLevel, maxZoomLevel, hasMatchingLevels] = _fitImagePyramid(
       pyramid,
       this[_pyramid]
     )
@@ -4726,7 +4726,7 @@ class VolumeImageViewer {
         wrapX: false,
         bandCount: 1,
         /** Avoid interpolation for single resolution (avoid blocky pixels) */
-        interpolate: fittedPyramid.resolutions.length > 1
+        interpolate: hasMatchingLevels === true
       })
       source.on('tileloaderror', (event) => {
         console.error(`error loading tile of segment "${segmentUID}"`, event.tile?.error_?.message || event)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -626,67 +626,6 @@ function _getColorPaletteStyleForTileLayer ({
 }
 
 /**
- * Build OpenLayers style expression for coloring a WebGL PointLayer.
- *
- * @param {Object} styleOptions - Style options
- * @param {string} styleOptions.key - Name of a property for which values
- * should be colorized
- * @param {number} styleOptions.minValue - Mininum value of the output range
- * @param {number} styleOptions.maxValue - Maxinum value of the output range
- * @param {number[]} styleOptions.color - RGB color triplet
- *
- * @returns {Object} color style expression and corresponding variables
- *
- * @private
- */
-function _getColorInterpolationStyleForPointLayer ({
-  key,
-  minValue,
-  maxValue,
-  color
-}) {
-  const minIndexValue = 0
-  const maxIndexValue = 1
-  const indexExpression = [
-    '+',
-    [
-      '/',
-      [
-        '*',
-        [
-          '-',
-          ['get', key],
-          minValue
-        ],
-        [
-          '-',
-          maxIndexValue,
-          minIndexValue
-        ]
-      ],
-      [
-        '-',
-        maxValue,
-        minValue
-      ]
-    ],
-    minIndexValue
-  ]
-
-  const expression = [
-    'interpolate',
-    ['linear'],
-    indexExpression,
-    0,
-    [255, 255, 255, 1],
-    1,
-    rgb2hex(color)
-  ]
-
-  return { color: expression }
-}
-
-/**
  * Build OpenLayers style expression for coloring a WebGL TileLayer.
  *
  * @param {Object} styleOptions - Style options
@@ -1728,7 +1667,7 @@ class VolumeImageViewer {
           }
         }
       },
-      { 
+      {
         hitTolerance: 1,
         layerFilter: (layer) => (layer instanceof VectorLayer || layer instanceof WebGLVector)
       })
@@ -1780,7 +1719,7 @@ class VolumeImageViewer {
             clickEvent = null
           }
         },
-        { 
+        {
           hitTolerance: 1,
           layerFilter: (layer) => (layer instanceof VectorLayer || layer instanceof WebGLVector)
         }
@@ -1830,7 +1769,7 @@ class VolumeImageViewer {
             clickEvent = null
           }
         },
-        { 
+        {
           hitTolerance: 1,
           layerFilter: (layer) => (layer instanceof VectorLayer || layer instanceof WebGLVector)
         }
@@ -4197,10 +4136,10 @@ class VolumeImageViewer {
         'circle-displacement': [0, 0],
         'circle-opacity': annotationGroup.style.opacity,
         'circle-fill-color': [
-          'match', 
-          ['get', 'hover'], 
-          1, 
-          rgb2hex(this[_options].highlightColor), 
+          'match',
+          ['get', 'hover'],
+          1,
+          rgb2hex(this[_options].highlightColor),
           rgb2hex(annotationGroup.style.color)
         ]
       }
@@ -4226,8 +4165,8 @@ class VolumeImageViewer {
            * Ideally, we would use a color palette to colorize objects.
            * However, it appears the "palette" expression is not yet supported for
            * styling PointLayer.
-           * 
-           * Create a heat map effect: normalize property values to 0-1 range and 
+           *
+           * Create a heat map effect: normalize property values to 0-1 range and
            * interpolate colors from white to annotation color.
            */
           Object.assign(pointsStyle, {
@@ -4241,17 +4180,17 @@ class VolumeImageViewer {
                   [
                     '*',
                     ['-', ['get', key], properties[key].min],
-                    ['-', properties[key].min, properties[key].max],
+                    ['-', properties[key].min, properties[key].max]
                   ],
-                  ['-', properties[key].max, properties[key].min],
+                  ['-', properties[key].max, properties[key].min]
                 ],
-                minIndexValue,
+                properties[key].min
               ],
               0,
-              [255, 255, 255, 1], 
+              [255, 255, 255, 1],
               1,
-              annotationGroup.style.color,
-            ],
+              annotationGroup.style.color
+            ]
           })
         }
       }
@@ -4468,7 +4407,7 @@ class VolumeImageViewer {
     if (annotationGroup.layers[0]) {
       annotationGroup.layers[0].setStyle(this.getGraphicTypeLayerStyle(annotationGroup))
     }
-    
+
     if (annotationGroup.graphicType !== 'POINT' && annotationGroup.layers[1]) {
       if (annotationGroup.numberOfAnnotations > 1000) {
         annotationGroup.layers[1].setStyle(getClusterStyleFunc(annotationGroup.style, annotationGroup.layers[1].getSource()))

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -4735,7 +4735,8 @@ class VolumeImageViewer {
         projection: this[_projection],
         wrapX: false,
         bandCount: 1,
-        interpolate: true
+        /** Avoid interpolation for single resolution (avoid blocky pixels) */
+        interpolate: fittedPyramid.resolutions.length > 1
       })
       source.on('tileloaderror', (event) => {
         console.error(`error loading tile of segment "${segmentUID}"`, event.tile?.error_?.message || event)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -755,7 +755,9 @@ class VolumeImageViewer {
    * resolutions.
    * @param {boolean} [options.useTileGridResolutions=true] If false,
    * zoom will not be limited and the image will fit the viewport extent (no clipping).
-   * This option will be ignored if there are no thumbnail images available or there's just one image.
+   * Note: This option will be ignored if there are no thumbnail images available or its just one image.
+   * If you set skipThumbnails to true, this option is not needed.
+   * @param {boolean} [options.skipThumbnails=false] If true, thumbnail images will not be loaded as part of the pyramid.
    */
   constructor (options) {
     this[_options] = options
@@ -810,6 +812,10 @@ class VolumeImageViewer {
       for (const key in this[_options].clientMapping) {
         this[_clients][key] = this[_options].clientMapping[key]
       }
+    }
+
+    if (this[_options].skipThumbnails == null) {
+      this[_options].skipThumbnails = false
     }
 
     if (this[_options].annotationOptions) {
@@ -919,6 +925,9 @@ class VolumeImageViewer {
     const filterImagesByResolution = (metadata) => {
       const pyramidBaseMetadata = metadata[metadata.length - 1]
       const filteredMetadata = metadata.filter(image => {
+        if (hasImageFlavor(image, ImageFlavors.THUMBNAIL) && this[_options].skipThumbnails === true) {
+          return false
+        }
         if (hasImageFlavor(image, ImageFlavors.THUMBNAIL)) {
           const hasThumbnailEquivalentVolumeImage = metadata.some(
             (img) =>
@@ -1087,7 +1096,8 @@ class VolumeImageViewer {
     })
 
     let mapViewResolutions =
-      this[_options].useTileGridResolutions === false
+      this[_options].useTileGridResolutions === false ||
+      this[_options].skipThumbnails === true
         ? undefined
         : this[_tileGrid].getResolutions()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5734,7 +5734,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-ol@^10.4.0:
+ol@^10.6.0:
   version "10.6.1"
   resolved "https://registry.yarnpkg.com/ol/-/ol-10.6.1.tgz#950f3914b4eec978f087b36aa74ce1e18c41ab09"
   integrity sha512-xp174YOwPeLj7c7/8TCIEHQ4d41tgTDDhdv6SqNdySsql5/MaFJEJkjlsYcvOPt7xA6vrum/QG4UdJ0iCGT1cg==


### PR DESCRIPTION
Turned off interpolated values when resampling. By default, the nearest neighbor is used when resampling.
- https://github.com/ImagingDataCommons/slim/issues/317

Before:
<img width="630" height="866" alt="Screenshot 2025-08-21 at 17 14 33" src="https://github.com/user-attachments/assets/13a646e4-a0c8-465f-86be-7354fd7c4dfd" />

After:
<img width="630" height="868" alt="Screenshot 2025-08-21 at 17 13 45" src="https://github.com/user-attachments/assets/d9a89d66-f473-4b70-8824-5c36c95cff5c" />

