### PR TITLE
chore: upgrade pnpm to 11.9.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.34.1
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.34.1
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["18.x", "24.x"]
+        node-version: ["24.x"]
 
     steps:
       - uses: actions/checkout@v7

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dicomweb",
     "microscopy"
   ],
-  "packageManager": "pnpm@10.34.1",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "main": "./src/dicom-microscopy-viewer.js",
   "exports": {
     ".": "./dist/dicomMicroscopyViewer.bundle.min.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 packages:
   - .
 
+shamefullyHoist: true
+strictPeerDependencies: false
+
+allowBuilds:
+  core-js: true
+  core-js-pure: true
+  unrs-resolver: true
+
 overrides:
   braces: 3.0.3
   form-data: 3.0.5


### PR DESCRIPTION
## Summary
- Bump `packageManager` to pnpm 11.9.0
- Move `shamefullyHoist` and `strictPeerDependencies` from `.npmrc` into `pnpm-workspace.yaml` (required for pnpm 11)
- Allow `core-js`, `core-js-pure`, and `unrs-resolver` build scripts via `allowBuilds`

## Test plan
- [ ] `corepack enable && corepack install`
- [ ] `pnpm install`
- [ ] `pnpm run test`
- [ ] `pnpm run build`