### PR TITLE
fix: bump fast-uri to 3.1.5 for Dependabot #111

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   adm-zip: 0.6.0
   brace-expansion: 1.1.16
   braces: 3.0.3
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   form-data: 3.0.5
   js-yaml: 3.15.0
   linkify-it: 5.0.2
@@ -2077,8 +2077,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -5549,7 +5549,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6213,7 +6213,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ overrides:
   adm-zip: 0.6.0
   brace-expansion: 1.1.16
   braces: 3.0.3
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   form-data: 3.0.5
   js-yaml: 3.15.0
   linkify-it: 5.0.2


### PR DESCRIPTION
## Summary
- Bumps the `fast-uri` pnpm override from `3.1.4` to `3.1.5` to clear [Dependabot alert #111](https://github.com/ImagingDataCommons/dicom-microscopy-viewer/security/dependabot/111) (host confusion via backslash authority introducer).

## Test plan
- [x] `pnpm install` resolves `fast-uri@3.1.5`
- [x] `pnpm test` — 7 suites / 180 tests passed
- [ ] Confirm alert #111 closes after merge