### PR TITLE
fix: collapsible visibility-gated SEG/PM legend (slim#409)

### DIFF
--- a/config/webpack/webpack-base.js
+++ b/config/webpack/webpack-base.js
@@ -46,7 +46,16 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        exclude: [/(node_modules)/, /(codecs)/, /(dicomicc)/],
+        /**
+         * Only transpile this package's own sources. Excluding on a bare
+         * /(node_modules)/ pattern breaks when the package itself is built
+         * from a directory whose path contains "node_modules" (e.g. pnpm
+         * builds git-hosted dependencies inside its store), which silently
+         * skips babel — and babel-plugin-transform-import-meta — for every
+         * module, so webpack then fails to resolve
+         * new URL('./dataLoader.worker.min.js', import.meta.url).
+         */
+        include: context,
         use: {
           loader: 'babel-loader',
         },

--- a/config/webpack/webpack-bundle.js
+++ b/config/webpack/webpack-bundle.js
@@ -50,7 +50,9 @@ module.exports = {
       },
       {
         test: /\.js$/,
-        exclude: [/(node_modules)/, /(codecs)/, /(dicomicc)/],
+        /** See webpack-base.js: include (not exclude) so builds work from
+         * paths containing "node_modules" (pnpm git-dependency store). */
+        include: context,
         use: {
           loader: 'babel-loader',
         },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
     "webpack:bundle": "webpack --progress --config ./config/webpack/webpack-bundle",
     "webpack:dynamic-import:watch": "webpack --progress --watch --config ./config/webpack/webpack-dynamic-import",
     "webpack:watch": "webpack --progress --watch  --config ./config/webpack/webpack-bundle",
-    "prepare": "husky"
+    "prepare": "node ./scripts/prepare.mjs"
   }
 }

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * pnpm/npm prepare hook:
+ * - install husky when developing inside a git checkout
+ * - build dist/ when missing (git dependency installs / CI consumers)
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const distEntry = join(root, 'dist', 'dicomMicroscopyViewer.bundle.min.js')
+
+if (existsSync(join(root, '.git'))) {
+  spawnSync('pnpm', ['exec', 'husky'], { cwd: root, stdio: 'inherit' })
+}
+
+if (!existsSync(distEntry)) {
+  console.info('[prepare] dist/ missing — running webpack build')
+  const result = spawnSync('pnpm', ['run', 'build'], {
+    cwd: root,
+    stdio: 'inherit',
+  })
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -757,6 +757,7 @@ const _mapViewResolutions = Symbol('mapViewResolutions')
 const _paletteDisplayGammaCorrectionEnabled = Symbol(
   'paletteDisplayGammaCorrectionEnabled',
 )
+const _derivedLegendCollapsed = Symbol('derivedLegendCollapsed')
 
 /**
  * Interactive viewer for DICOM VL Whole Slide Microscopy Image instances
@@ -845,6 +846,8 @@ class VolumeImageViewer {
       element: document.createElement('div'),
       offset: [7, 5],
     })
+    /** Collapsed state for the in-viewport fractional/mapping legend. */
+    this[_derivedLegendCollapsed] = false
 
     if (this[_options].client) {
       this[_clients].default = this[_options].client
@@ -5482,6 +5485,8 @@ class VolumeImageViewer {
         view.animate({ zoom: segment.minZoomLevel })
       }
     }
+
+    this._syncStackedDerivedLegendOverlays()
   }
 
   /**
@@ -5526,8 +5531,11 @@ class VolumeImageViewer {
   }
 
   /**
-   * Single viewport overlay: all visible fractional segments and parametric
-   * maps as rows in one column (property type Code Meaning / LUT label).
+   * Single viewport overlay: all fractional segments and parametric maps as
+   * rows in one column (property type Code Meaning / LUT label).
+   *
+   * The legend is hidden when no overlay is currently visible, and is
+   * collapsible so it does not permanently obscure the image (slim#409).
    *
    * @private
    */
@@ -5553,8 +5561,8 @@ class VolumeImageViewer {
     root.style.display = 'flex'
     root.style.flexDirection = 'column'
     root.style.alignItems = 'stretch'
-    root.style.gap = '10px'
-    root.style.padding = '8px'
+    root.style.gap = '8px'
+    root.style.padding = '6px 8px'
     root.style.backgroundColor = 'rgba(255, 255, 255, 0.94)'
     root.style.borderRadius = '6px'
     root.style.margin = '1px'
@@ -5562,14 +5570,17 @@ class VolumeImageViewer {
     root.style.marginLeft = '4px'
     root.style.boxShadow = '0 1px 4px rgba(0, 0, 0, 0.12)'
 
-    let rowCount = 0
-
     /**
-     * Render every fractional segment / parametric map (not only the visible
-     * ones) so the in-viewport legend doubles as a visibility control: hidden
+     * Collect fractional segments / parametric maps that have a palette so
+     * the in-viewport legend doubles as a visibility control: hidden
      * overlays appear dimmed with an "off" toggle and can be re-enabled
      * without opening the host application's side panel (see issue #240).
+     * The whole legend stays hidden until at least one of those overlays is
+     * visible (see ImagingDataCommons/slim#409).
      */
+    const rows = []
+    let visibleCount = 0
+
     const segmentUids = Object.keys(this[_segments]).sort()
     for (let s = 0; s < segmentUids.length; s++) {
       const uid = segmentUids[s]
@@ -5581,21 +5592,26 @@ class VolumeImageViewer {
       if (data == null || data.length === 0) {
         continue
       }
+      const isVisible = rec.layer.getVisible()
+      if (isVisible) {
+        visibleCount += 1
+      }
       const prop = rec.segment?.propertyType
       const title =
         prop?.CodeMeaning != null && String(prop.CodeMeaning).trim() !== ''
           ? prop.CodeMeaning
           : (rec.segment?.label ?? 'Fractional')
 
-      this._appendDerivedLegendRow(root, title, data, {
+      rows.push({
+        title,
+        colors: data,
         minValue: rec.minStoredValue,
         maxValue: rec.maxStoredValue,
         useRealWorldValues: false,
-        isVisible: rec.layer.getVisible(),
+        isVisible,
         kind: 'segment',
         uid,
       })
-      rowCount += 1
     }
 
     const mappingUids = Object.keys(this[_mappings]).sort()
@@ -5615,32 +5631,98 @@ class VolumeImageViewer {
         maxValue = mapping.realWorldValueRange[1]
         useRealWorldValues = true
       }
+      const isVisible = mapping.layer.getVisible()
+      if (isVisible) {
+        visibleCount += 1
+      }
       const mapTitle =
         mapping.mapping?.label != null &&
         String(mapping.mapping.label).trim() !== ''
           ? mapping.mapping.label
           : 'Parametric map'
 
-      this._appendDerivedLegendRow(root, mapTitle, mapData, {
+      rows.push({
+        title: mapTitle,
+        colors: mapData,
         minValue,
         maxValue,
         useRealWorldValues,
-        isVisible: mapping.layer.getVisible(),
+        isVisible,
         kind: 'mapping',
         uid: muid,
       })
-      rowCount += 1
     }
 
     const parentEl = root.parentNode
-    if (rowCount === 0) {
+    const hideLegend = () => {
       if (this.segmentOverlay.getMap() != null) {
         this[_map].removeOverlay(this.segmentOverlay)
       }
       if (parentEl != null) {
         parentEl.style.display = 'none'
       }
+    }
+
+    if (rows.length === 0 || visibleCount === 0) {
+      hideLegend()
       return
+    }
+
+    const collapsed = this[_derivedLegendCollapsed] === true
+    const header = document.createElement('button')
+    header.type = 'button'
+    header.style.display = 'flex'
+    header.style.flexDirection = 'row'
+    header.style.alignItems = 'center'
+    header.style.justifyContent = 'space-between'
+    header.style.gap = '8px'
+    header.style.width = '100%'
+    header.style.padding = '0'
+    header.style.margin = '0'
+    header.style.border = 'none'
+    header.style.background = 'transparent'
+    header.style.cursor = 'pointer'
+    header.style.font = 'inherit'
+    header.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
+    header.title = collapsed ? 'Expand legend' : 'Collapse legend'
+    header.setAttribute('aria-label', header.title)
+
+    const headerLabel = document.createElement('span')
+    headerLabel.textContent = collapsed
+      ? `Legend (${visibleCount} visible)`
+      : 'Legend'
+    headerLabel.style.fontSize = '12px'
+    headerLabel.style.fontWeight = '700'
+    headerLabel.style.color = 'rgba(0, 0, 0, 0.85)'
+
+    const chevron = document.createElement('span')
+    chevron.textContent = collapsed ? '▸' : '▾'
+    chevron.style.fontSize = '12px'
+    chevron.style.color = 'rgba(0, 0, 0, 0.55)'
+    chevron.style.lineHeight = '1'
+
+    header.appendChild(headerLabel)
+    header.appendChild(chevron)
+    header.addEventListener('click', (event) => {
+      event.stopPropagation()
+      this[_derivedLegendCollapsed] = !this[_derivedLegendCollapsed]
+      this._syncStackedDerivedLegendOverlays()
+    })
+    root.appendChild(header)
+
+    if (!collapsed) {
+      root.style.gap = '10px'
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i]
+        this._appendDerivedLegendRow(root, row.title, row.colors, {
+          minValue: row.minValue,
+          maxValue: row.maxValue,
+          useRealWorldValues: row.useRealWorldValues,
+          isVisible: row.isVisible,
+          kind: row.kind,
+          uid: row.uid,
+        })
+      }
     }
 
     if (parentEl != null) {
@@ -6353,6 +6435,7 @@ class VolumeImageViewer {
 
     mapping.layer.setVisible(true)
     this.setParameterMappingStyle(mappingUID, styleOptions)
+    this._syncStackedDerivedLegendOverlays()
   }
 
   /**

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5490,6 +5490,7 @@ class VolumeImageViewer {
 
     segment.layer.setVisible(true)
     this.setSegmentStyle(segmentUID, styleOptions)
+    this._syncStackedDerivedLegendOverlays()
 
     if (!segment.hasLoader) {
       console.debug(
@@ -5509,8 +5510,6 @@ class VolumeImageViewer {
         view.animate({ zoom: segment.minZoomLevel })
       }
     }
-
-    this._syncStackedDerivedLegendOverlays()
   }
 
   /**
@@ -5699,14 +5698,17 @@ class VolumeImageViewer {
     header.style.flexDirection = 'row'
     header.style.alignItems = 'center'
     header.style.justifyContent = 'space-between'
-    header.style.gap = '8px'
+    header.style.gap = '10px'
     header.style.width = '100%'
-    header.style.padding = '0'
+    header.style.minHeight = '28px'
+    header.style.padding = '4px 6px'
     header.style.margin = '0'
-    header.style.border = 'none'
-    header.style.background = 'transparent'
+    header.style.border = '1px solid rgba(0, 0, 0, 0.12)'
+    header.style.borderRadius = '4px'
+    header.style.background = 'rgba(0, 0, 0, 0.04)'
     header.style.cursor = 'pointer'
     header.style.font = 'inherit'
+    header.style.boxSizing = 'border-box'
     header.setAttribute('aria-expanded', collapsed ? 'false' : 'true')
     header.title = collapsed ? 'Expand legend' : 'Collapse legend'
     header.setAttribute('aria-label', header.title)
@@ -5715,15 +5717,27 @@ class VolumeImageViewer {
     headerLabel.textContent = collapsed
       ? `Legend (${visibleCount} visible)`
       : 'Legend'
-    headerLabel.style.fontSize = '12px'
+    headerLabel.style.fontSize = '13px'
     headerLabel.style.fontWeight = '700'
     headerLabel.style.color = 'rgba(0, 0, 0, 0.85)'
 
+    /**
+     * Explicit collapse control: a padded chevron affordance so the control
+     * remains obvious at viewport scale (slim#409 / PR feedback).
+     */
     const chevron = document.createElement('span')
     chevron.textContent = collapsed ? '▸' : '▾'
-    chevron.style.fontSize = '12px'
-    chevron.style.color = 'rgba(0, 0, 0, 0.55)'
+    chevron.style.display = 'inline-flex'
+    chevron.style.alignItems = 'center'
+    chevron.style.justifyContent = 'center'
+    chevron.style.minWidth = '22px'
+    chevron.style.minHeight = '22px'
+    chevron.style.fontSize = '16px'
+    chevron.style.fontWeight = '700'
+    chevron.style.color = 'rgba(0, 0, 0, 0.75)'
     chevron.style.lineHeight = '1'
+    chevron.style.borderRadius = '3px'
+    chevron.style.background = 'rgba(0, 0, 0, 0.06)'
 
     header.appendChild(headerLabel)
     header.appendChild(chevron)


### PR DESCRIPTION
## Summary
Addresses [ImagingDataCommons/slim#409](https://github.com/ImagingDataCommons/slim/issues/409):

- Hide the in-viewport probabilistic SEG / parametric-map legend when no overlay is currently visible
- Add a collapse/expand control so the legend does not permanently obscure the image
- Refresh the legend from `showSegment` / `showParameterMapping` so legend checkboxes stay in sync with host side-panel visibility toggles
- Build `dist/` from `prepare` when missing so git-hosted consumers (slim) can install this branch without an npm publish

When at least one overlay is visible, the legend still lists all fractional segments and parametric maps (including hidden ones, dimmed) so users can re-enable them from the viewport (same pattern as #240).

Companion slim PR: https://github.com/ImagingDataCommons/slim/pull/410

## Test plan
- [x] `pnpm test` — 180 tests passed
- [ ] Load a study with multiple fractional SEGs; confirm legend is absent until a segment is shown
- [ ] Toggle segments from the side panel; confirm legend checkboxes match
- [ ] Toggle from the legend; confirm side-panel switches update (host app)
- [ ] Collapse the legend; confirm only the compact header remains and the image is unobscured
- [ ] Hide the last visible overlay; confirm the legend disappears