### PR TITLE
fix: correct TILED_SPARSE segmentation alignment and add zoom functionality

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -246,6 +246,7 @@ function getFrameMapping(metadata) {
   return {
     frameMapping,
     numberOfChannels,
+    dimensionOrganizationType,
   }
 }
 

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -627,10 +627,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
       const resolution = segPixelSpacing[0] / refBasePixelSpacing[0]
       const finalResolution = parseFloat(resolution.toFixed(4))
 
-      console.log(
-        `[SPARSE] Resolution: exact=${resolution}, final=${finalResolution}`,
-      )
-
       /**
        * For TILED_SPARSE overlays at non-matching resolutions:
        * Calculate where the SEG's origin is in base image pixel coordinates,
@@ -692,13 +688,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
             offsetY = physicalOffsetY / (rowCosines[1] * refBasePixelSpacing[0])
           }
         }
-
-        console.log(
-          '[SPARSE] Origin offset - physical:',
-          { physicalOffsetX, physicalOffsetY },
-          'pixels:',
-          { offsetX, offsetY },
-        )
       }
 
       /**
@@ -716,14 +705,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
         offsetX + scaledWidth,
         -(offsetY + 1),
       ]
-      console.log(
-        '[SPARSE] Calculated extent:',
-        extent,
-        'from SEG size:',
-        { segCols, segRows },
-        'scaled by:',
-        resolution,
-      )
       fittedPyramid.extent = extent
 
       /**
@@ -735,10 +716,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
       const perframeFuncGroups = segmentation.PerFrameFunctionalGroupsSequence
       const tileHeight = segmentation.Rows
       const tileWidth = segmentation.Columns
-
-      console.log(
-        `[SPARSE] Analyzing ${perframeFuncGroups?.length || 0} frames, tile size: ${tileWidth}x${tileHeight}, resolution: ${resolution.toFixed(4)}`,
-      )
 
       if (perframeFuncGroups && perframeFuncGroups.length > 0) {
         /** Check all frames to see if they have consistent sub-tile offsets */
@@ -774,12 +751,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
                 subTileRowOffset,
                 subTileColOffset,
               })
-
-              console.log(
-                `[SPARSE] Frame ${frameIdx}: pos=(${rowPosition}, ${colPosition}), ` +
-                  `tileIdx=(${tileRowIndex}, ${tileColIndex}), ` +
-                  `subTileOffset=(${subTileRowOffset}, ${subTileColOffset})`,
-              )
             }
           }
         }
@@ -800,11 +771,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
            * - Negative y offset shifts tiles down (more negative Y)
            */
           tileOriginOffset = [baseColOffset, -baseRowOffset]
-
-          console.log(
-            `[SPARSE] Calculated tileOriginOffset: [${tileOriginOffset[0].toFixed(2)}, ${tileOriginOffset[1].toFixed(2)}] ` +
-              `(from subTileOffset=(${firstOffset.subTileRowOffset}, ${firstOffset.subTileColOffset}) * resolution=${resolution.toFixed(4)})`,
-          )
 
           /** Check if all frames have consistent offsets */
           const allConsistent = subTileOffsets.every(
@@ -834,12 +800,6 @@ function _fitImagePyramid(pyramid, refPyramid) {
         -(offsetY + 1) + tileOriginOffset[1],
       ]
 
-      console.log(
-        `[SPARSE] Origin adjustment: ` +
-          `extentOffset=(${offsetX.toFixed(1)}, ${offsetY.toFixed(1)}), ` +
-          `pyramidOrigin=[${pyramid.origins[j][0]}, ${pyramid.origins[j][1]}], ` +
-          `adjustedOrigin=[${adjustedOrigin[0].toFixed(1)}, ${adjustedOrigin[1].toFixed(1)}]`,
-      )
       fittedPyramid.origins.push(adjustedOrigin)
       fittedPyramid.gridSizes.push([...pyramid.gridSizes[j]])
       fittedPyramid.tileSizes.push([...pyramid.tileSizes[j]])

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -343,6 +343,12 @@ function _areImagePyramidsEqual(pyramid, refPyramid) {
   return true
 }
 
+/**
+ * Cache for empty tiles to avoid repeated allocation for TILED_SPARSE images.
+ * Key format: "columns-rows-samplesPerPixel-bitsAllocated-photometricInterpretation"
+ */
+const emptyTileCache = new Map()
+
 function _createEmptyTile({
   columns,
   rows,
@@ -350,6 +356,12 @@ function _createEmptyTile({
   bitsAllocated,
   photometricInterpretation,
 }) {
+  const cacheKey = `${columns}-${rows}-${samplesPerPixel}-${bitsAllocated}-${photometricInterpretation}`
+
+  if (emptyTileCache.has(cacheKey)) {
+    return emptyTileCache.get(cacheKey)
+  }
+
   let pixelArray
   if (bitsAllocated <= 8) {
     pixelArray = new Uint8Array(columns * rows * samplesPerPixel)
@@ -357,19 +369,20 @@ function _createEmptyTile({
     pixelArray = new Float32Array(columns * rows * samplesPerPixel)
   }
 
-  // Fill white in case of color and black in case of monochrome.
+  /** Fill white for color images, black for monochrome */
   let fillValue = 2 ** bitsAllocated - 1
   if (photometricInterpretation === 'MONOCHROME2') {
     if (bitsAllocated <= 16) {
       fillValue = 0
     } else {
-      // Float pixel data
       fillValue = -(2 ** bitsAllocated - 1) / 2
     }
   }
   for (let i = 0; i < pixelArray.length; i++) {
     pixelArray[i] = fillValue
   }
+
+  emptyTileCache.set(cacheKey, pixelArray)
   return pixelArray
 }
 
@@ -381,6 +394,12 @@ function _createTileLoadFunction({
   iccOutputType,
   targetElement,
 }) {
+  /**
+   * Pre-cache values that don't change per tile request.
+   * This avoids repeated lookups in the hot path.
+   */
+  const channelSuffix = `-${channel}`
+
   return async (z, y, x) => {
     /**
      * Build frame mapping key from tile coordinates.
@@ -388,8 +407,7 @@ function _createTileLoadFunction({
      * - x corresponds to row index in the frame mapping
      * - y corresponds to column index in the frame mapping
      */
-    let index = `${x + 1}-${y + 1}`
-    index += `-${channel}`
+    const index = `${x + 1}-${y + 1}${channelSuffix}`
 
     if (pyramid.metadata[z] === undefined) {
       throw new Error(
@@ -399,163 +417,24 @@ function _createTileLoadFunction({
       )
     }
 
-    const studyInstanceUID = pyramid.metadata[z].StudyInstanceUID
-    const seriesInstanceUID = pyramid.metadata[z].SeriesInstanceUID
     const path = pyramid.frameMappings[z][index]
-
-    /** Debug: Log when a sparse tile is found */
-    const dimensionOrgTypeCheck = pyramid.dimensionOrganizationTypes?.[z]
-    if (path != null && dimensionOrgTypeCheck !== 'TILED_FULL') {
-      console.log(`[SPARSE TILE FOUND] key="${index}" -> path="${path}"`)
-    }
-
-    let src
-    if (path != null) {
-      src = ''
-      if (client.wadoURL !== undefined) {
-        src += client.wadoURL
-      }
-      src +=
-        '/studies/' +
-        studyInstanceUID +
-        '/series/' +
-        seriesInstanceUID +
-        '/instances/' +
-        path
-    }
-
     const refImage = pyramid.metadata[z]
     const columns = refImage.Columns
     const rows = refImage.Rows
     const bitsAllocated = refImage.BitsAllocated
-    const pixelRepresentation = refImage.PixelRepresentation
     const samplesPerPixel = refImage.SamplesPerPixel
     const photometricInterpretation = refImage.PhotometricInterpretation
-    const sopClassUID = refImage.SOPClassUID
 
-    if (src != null) {
-      const sopInstanceUID = dwc.utils.getSOPInstanceUIDFromUri(src)
-      const frameNumbers = dwc.utils.getFrameNumbersFromUri(src)
-
-      if (samplesPerPixel === 1) {
-        logger.debug(
-          `retrieve frame ${frameNumbers} of monochrome image ` +
-            `for channel "${channel}" at tile position (${x + 1}, ${y + 1}) ` +
-            `at zoom level ${z}`,
-        )
-      } else {
-        logger.debug(
-          `retrieve frame ${frameNumbers} of color image ` +
-            `at tile position (${x + 1}, ${y + 1}) at zoom level ${z}`,
-        )
-      }
-
-      const octetStreamMediaType = 'application/octet-stream'
-      /*
-       * Use of the "*" transfer syntax is a hack to work around standard
-       * compliance issues of the Google Cloud Healthcare API.
-       * It will return bulkdata encoded with the transfer syntax of the
-       * stored data set (uncompressed or compressed). The decoder can then not
-       * rely on the media type specified by the "Content-Type" header in the
-       * response message, but will need to determine it from the payload.
-       * Only application/octet-stream with "*" is requested here; decoders
-       * determine the actual compression format (e.g. JPEG, JPEG-LS, JPEG 2000)
-       * from the payload when processing the frames.
-       */
-      const octetStreamTransferSyntaxUID = '*'
-
-      const mediaTypes = []
-      mediaTypes.push(
-        ...[
-          {
-            mediaType: octetStreamMediaType,
-            transferSyntaxUID: octetStreamTransferSyntaxUID,
-          },
-        ],
-      )
-
-      const frameInfo = {
-        studyInstanceUID,
-        seriesInstanceUID,
-        sopInstanceUID,
-        sopClassUID,
-        frameNumber: frameNumbers[0],
-        channelIdentifier: String(channel),
-      }
-      publish(targetElement, EVENT.FRAME_LOADING_STARTED, frameInfo)
-
-      const retrieveOptions = {
-        studyInstanceUID,
-        seriesInstanceUID,
-        sopInstanceUID,
-        frameNumbers,
-        mediaTypes,
-      }
-      return client
-        .retrieveInstanceFrames(retrieveOptions)
-        .then((rawFrames) => {
-          return _decodeAndTransformFrame({
-            frame: rawFrames[0],
-            frameNumber: frameNumbers[0],
-            bitsAllocated,
-            pixelRepresentation,
-            columns,
-            rows,
-            samplesPerPixel,
-            sopInstanceUID,
-            metadata: pyramid.metadata,
-            iccProfiles,
-            iccOutputType,
-          }).then((pixelArray) => {
-            if (pixelArray.constructor === Float64Array) {
-              // TODO: handle Float64Array using LUT
-              throw new Error('Double Float Pixel Data is not (yet) supported.')
-            }
-            publish(targetElement, EVENT.FRAME_LOADING_ENDED, {
-              pixelArray,
-              ...frameInfo,
-            })
-            if (samplesPerPixel === 3 && bitsAllocated === 8) {
-              // Rendering of color images requires unsigned 8-bit integers
-              return pixelArray
-            }
-            // Rendering of grayscale images requires floating point values
-            return new Float32Array(
-              pixelArray,
-              pixelArray.byteOffset,
-              pixelArray.byteLength / pixelArray.BYTES_PER_ELEMENT,
-            )
-          })
-        })
-        .catch((error) => {
-          publish(targetElement, EVENT.FRAME_LOADING_ENDED, frameInfo)
-          publish(targetElement, EVENT.FRAME_LOADING_ERROR, frameInfo)
-          return Promise.reject(
-            new Error(
-              `Failed to load frames ${frameNumbers} ` +
-                `of SOP instance "${sopInstanceUID}" ` +
-                `for channel "${channel}" ` +
-                `at tile position (${x + 1}, ${y + 1}) ` +
-                `at zoom level ${z}: `,
-              error,
-            ),
-          )
-        })
-    } else {
-      /**
-       * For TILED_SPARSE images, missing tiles are expected behavior.
-       * Only log warnings for TILED_FULL images where missing tiles indicate a problem.
-       */
+    /**
+     * Fast path for missing tiles (common in TILED_SPARSE).
+     * Return cached empty tile immediately without further processing.
+     */
+    if (path == null) {
       const dimensionOrganizationType = pyramid.dimensionOrganizationTypes?.[z]
       if (dimensionOrganizationType === 'TILED_FULL') {
         console.warn(
           `could not load tile "${index}" at level ${z}, ` +
             'this tile does not exist',
-        )
-      } else {
-        logger.debug(
-          `Tile "${index}" at level ${z} does not exist ` +
-            '(expected for sparse image)',
         )
       }
       return _createEmptyTile({
@@ -566,6 +445,132 @@ function _createTileLoadFunction({
         photometricInterpretation,
       })
     }
+
+    /** Tile exists - do the full processing */
+    const studyInstanceUID = refImage.StudyInstanceUID
+    const seriesInstanceUID = refImage.SeriesInstanceUID
+    const pixelRepresentation = refImage.PixelRepresentation
+    const sopClassUID = refImage.SOPClassUID
+
+    let src = ''
+    if (client.wadoURL !== undefined) {
+      src += client.wadoURL
+    }
+    src +=
+      '/studies/' +
+      studyInstanceUID +
+      '/series/' +
+      seriesInstanceUID +
+      '/instances/' +
+      path
+
+    const sopInstanceUID = dwc.utils.getSOPInstanceUIDFromUri(src)
+    const frameNumbers = dwc.utils.getFrameNumbersFromUri(src)
+
+    if (samplesPerPixel === 1) {
+      logger.debug(
+        `retrieve frame ${frameNumbers} of monochrome image ` +
+          `for channel "${channel}" at tile position (${x + 1}, ${y + 1}) ` +
+          `at zoom level ${z}`,
+      )
+    } else {
+      logger.debug(
+        `retrieve frame ${frameNumbers} of color image ` +
+          `at tile position (${x + 1}, ${y + 1}) at zoom level ${z}`,
+      )
+    }
+
+    const octetStreamMediaType = 'application/octet-stream'
+    /*
+     * Use of the "*" transfer syntax is a hack to work around standard
+     * compliance issues of the Google Cloud Healthcare API.
+     * It will return bulkdata encoded with the transfer syntax of the
+     * stored data set (uncompressed or compressed). The decoder can then not
+     * rely on the media type specified by the "Content-Type" header in the
+     * response message, but will need to determine it from the payload.
+     * Only application/octet-stream with "*" is requested here; decoders
+     * determine the actual compression format (e.g. JPEG, JPEG-LS, JPEG 2000)
+     * from the payload when processing the frames.
+     */
+    const octetStreamTransferSyntaxUID = '*'
+
+    const mediaTypes = []
+    mediaTypes.push(
+      ...[
+        {
+          mediaType: octetStreamMediaType,
+          transferSyntaxUID: octetStreamTransferSyntaxUID,
+        },
+      ],
+    )
+
+    const frameInfo = {
+      studyInstanceUID,
+      seriesInstanceUID,
+      sopInstanceUID,
+      sopClassUID,
+      frameNumber: frameNumbers[0],
+      channelIdentifier: String(channel),
+    }
+    publish(targetElement, EVENT.FRAME_LOADING_STARTED, frameInfo)
+
+    const retrieveOptions = {
+      studyInstanceUID,
+      seriesInstanceUID,
+      sopInstanceUID,
+      frameNumbers,
+      mediaTypes,
+    }
+    return client
+      .retrieveInstanceFrames(retrieveOptions)
+      .then((rawFrames) => {
+        return _decodeAndTransformFrame({
+          frame: rawFrames[0],
+          frameNumber: frameNumbers[0],
+          bitsAllocated,
+          pixelRepresentation,
+          columns,
+          rows,
+          samplesPerPixel,
+          sopInstanceUID,
+          metadata: pyramid.metadata,
+          iccProfiles,
+          iccOutputType,
+        }).then((pixelArray) => {
+          if (pixelArray.constructor === Float64Array) {
+            // TODO: handle Float64Array using LUT
+            throw new Error('Double Float Pixel Data is not (yet) supported.')
+          }
+          publish(targetElement, EVENT.FRAME_LOADING_ENDED, {
+            pixelArray,
+            ...frameInfo,
+          })
+          if (samplesPerPixel === 3 && bitsAllocated === 8) {
+            // Rendering of color images requires unsigned 8-bit integers
+            return pixelArray
+          }
+          // Rendering of grayscale images requires floating point values
+          return new Float32Array(
+            pixelArray,
+            pixelArray.byteOffset,
+            pixelArray.byteLength / pixelArray.BYTES_PER_ELEMENT,
+          )
+        })
+      })
+      .catch((error) => {
+        publish(targetElement, EVENT.FRAME_LOADING_ENDED, frameInfo)
+        publish(targetElement, EVENT.FRAME_LOADING_ERROR, frameInfo)
+        return Promise.reject(
+          new Error(
+            `Failed to load frames ${frameNumbers} ` +
+              `of SOP instance "${sopInstanceUID}" ` +
+              `for channel "${channel}" ` +
+              `at tile position (${x + 1}, ${y + 1}) ` +
+              `at zoom level ${z}: `,
+            error,
+          ),
+        )
+      })
   }
 }
 

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -838,34 +838,80 @@ function _fitImagePyramid(pyramid, refPyramid) {
     }
   }
 
-  let minZoom = 0
-  for (let i = 0; i < refPyramid.resolutions.length; i++) {
-    for (let j = 0; j < fittedPyramid.resolutions.length; j++) {
-      if (refPyramid.resolutions[i] === fittedPyramid.resolutions[j]) {
-        minZoom = i
-        break
-      }
-    }
-  }
-  let maxZoom = refPyramid.resolutions.length - 1
-  for (let i = refPyramid.resolutions.length - 1; i >= minZoom; i--) {
-    for (let j = fittedPyramid.resolutions.length - 1; j >= 0; j--) {
-      if (refPyramid.resolutions[i] === fittedPyramid.resolutions[j]) {
-        maxZoom = i
-        break
-      }
-    }
-  }
-
   const hasMatchingLevels = matchingLevelIndices.length > 0
+  let minZoom = 0
+  let maxZoom = Math.max(refPyramid.resolutions.length - 1, 0)
+
+  if (hasMatchingLevels) {
+    /**
+     * Shared pyramid levels: clamp zoom to the matching base indices so the
+     * overlay is only preferred within its available resolution range.
+     */
+    for (let i = 0; i < refPyramid.resolutions.length; i++) {
+      for (let j = 0; j < fittedPyramid.resolutions.length; j++) {
+        if (refPyramid.resolutions[i] === fittedPyramid.resolutions[j]) {
+          minZoom = i
+          break
+        }
+      }
+    }
+    maxZoom = refPyramid.resolutions.length - 1
+    for (let i = refPyramid.resolutions.length - 1; i >= minZoom; i--) {
+      for (let j = fittedPyramid.resolutions.length - 1; j >= 0; j--) {
+        if (refPyramid.resolutions[i] === fittedPyramid.resolutions[j]) {
+          maxZoom = i
+          break
+        }
+      }
+    }
+  } else if (fittedPyramid.resolutions.length > 0) {
+    /**
+     * No shared levels (e.g. TILED_SPARSE at a non-matching spacing). The
+     * fitted pyramid has its own resolution(s) that are not in the base
+     * pyramid. Map each fitted resolution to the closest base zoom index so
+     * click-to-zoom / fit targets the fitted overlay instead of the full
+     * base range (0..n-1), which zooms incorrectly for single-level SEGs.
+     * See https://github.com/ImagingDataCommons/slim/issues/371
+     */
+    const closestZooms = fittedPyramid.resolutions.map((resolution) =>
+      _findClosestResolutionIndex(refPyramid.resolutions, resolution),
+    )
+    minZoom = Math.min(...closestZooms)
+    maxZoom = Math.max(...closestZooms)
+  }
 
   return [fittedPyramid, minZoom, maxZoom, hasMatchingLevels]
+}
+
+/**
+ * Find the index of the resolution closest to a target value.
+ *
+ * @param {number[]} resolutions - Sorted resolution array (coarsest → finest)
+ * @param {number} targetResolution - Resolution to match
+ * @returns {number} Index of the closest resolution
+ * @private
+ */
+function _findClosestResolutionIndex(resolutions, targetResolution) {
+  if (!resolutions || resolutions.length === 0) {
+    return 0
+  }
+  let bestIndex = 0
+  let bestDiff = Math.abs(resolutions[0] - targetResolution)
+  for (let i = 1; i < resolutions.length; i++) {
+    const diff = Math.abs(resolutions[i] - targetResolution)
+    if (diff < bestDiff) {
+      bestDiff = diff
+      bestIndex = i
+    }
+  }
+  return bestIndex
 }
 
 export {
   _areImagePyramidsEqual,
   _computeImagePyramid,
   _createTileLoadFunction,
+  _findClosestResolutionIndex,
   _fitImagePyramid,
   _getIccProfiles,
 }

--- a/src/pyramid.js
+++ b/src/pyramid.js
@@ -99,6 +99,7 @@ function _computeImagePyramid({ metadata }) {
 
   const pyramidMetadata = []
   const pyramidFrameMappings = []
+  const pyramidDimensionOrganizationTypes = []
   let pyramidNumberOfChannels
   for (let i = 0; i < metadata.length; i++) {
     if (metadata[0].FrameOfReferenceUID !== metadata[i].FrameOfReferenceUID) {
@@ -116,7 +117,8 @@ function _computeImagePyramid({ metadata }) {
     const cols = metadata[i].TotalPixelMatrixColumns || metadata[i].Columns
     const rows = metadata[i].TotalPixelMatrixRows || metadata[i].Rows
 
-    const { frameMapping, numberOfChannels } = getFrameMapping(metadata[i])
+    const { frameMapping, numberOfChannels, dimensionOrganizationType } =
+      getFrameMapping(metadata[i])
     if (i > 0) {
       if (pyramidNumberOfChannels !== numberOfChannels) {
         throw new Error(
@@ -177,6 +179,7 @@ function _computeImagePyramid({ metadata }) {
     } else {
       pyramidMetadata.push(metadata[i])
       pyramidFrameMappings.push(frameMapping)
+      pyramidDimensionOrganizationTypes.push(dimensionOrganizationType)
     }
   }
 
@@ -281,6 +284,7 @@ function _computeImagePyramid({ metadata }) {
     metadata: pyramidMetadata,
     frameMappings: pyramidFrameMappings,
     numberOfChannels: pyramidNumberOfChannels,
+    dimensionOrganizationTypes: pyramidDimensionOrganizationTypes,
   }
 }
 
@@ -378,6 +382,12 @@ function _createTileLoadFunction({
   targetElement,
 }) {
   return async (z, y, x) => {
+    /**
+     * Build frame mapping key from tile coordinates.
+     * Note: The function signature uses (z, y, x) where the mapping is:
+     * - x corresponds to row index in the frame mapping
+     * - y corresponds to column index in the frame mapping
+     */
     let index = `${x + 1}-${y + 1}`
     index += `-${channel}`
 
@@ -392,6 +402,13 @@ function _createTileLoadFunction({
     const studyInstanceUID = pyramid.metadata[z].StudyInstanceUID
     const seriesInstanceUID = pyramid.metadata[z].SeriesInstanceUID
     const path = pyramid.frameMappings[z][index]
+
+    /** Debug: Log when a sparse tile is found */
+    const dimensionOrgTypeCheck = pyramid.dimensionOrganizationTypes?.[z]
+    if (path != null && dimensionOrgTypeCheck !== 'TILED_FULL') {
+      console.log(`[SPARSE TILE FOUND] key="${index}" -> path="${path}"`)
+    }
+
     let src
     if (path != null) {
       src = ''
@@ -525,10 +542,22 @@ function _createTileLoadFunction({
           )
         })
     } else {
-      console.warn(
-        `could not load tile "${index}" at level ${z}, ` +
-          'this tile does not exist',
-      )
+      /**
+       * For TILED_SPARSE images, missing tiles are expected behavior.
+       * Only log warnings for TILED_FULL images where missing tiles indicate a problem.
+       */
+      const dimensionOrganizationType = pyramid.dimensionOrganizationTypes?.[z]
+      if (dimensionOrganizationType === 'TILED_FULL') {
+        console.warn(
+          `could not load tile "${index}" at level ${z}, ` +
+            'this tile does not exist',
+        )
+      } else {
+        logger.debug(
+          `Tile "${index}" at level ${z} does not exist ` +
+            '(expected for sparse image)',
+        )
+      }
       return _createEmptyTile({
         columns,
         rows,
@@ -569,6 +598,7 @@ function _fitImagePyramid(pyramid, refPyramid) {
     pixelSpacings: [],
     metadata: [],
     frameMappings: [],
+    dimensionOrganizationTypes: [],
   }
 
   if (matchingLevelIndices.length === 0) {
@@ -583,24 +613,240 @@ function _fitImagePyramid(pyramid, refPyramid) {
       const refBasePixelSpacing = getPixelSpacing(refBaseLevel)
       const segPixelSpacing = getPixelSpacing(segmentation)
 
-      /** Calculate resolution based on ratio of pixel spacings */
+      /**
+       * Calculate resolution based on ratio of pixel spacings.
+       * For TILED_SPARSE, we MUST use the exact resolution (not rounded)
+       * to ensure tiles are rendered at the correct scale and position.
+       * Rounding causes misalignment because the tiles would be scaled incorrectly.
+       */
       const resolution = segPixelSpacing[0] / refBasePixelSpacing[0]
-      const roundedResolution = Math.round(resolution)
+      const finalResolution = parseFloat(resolution.toFixed(4))
 
-      /** Handle resolution conflicts similar to _computeImagePyramid */
-      const finalResolution = fittedPyramid.resolutions.includes(
-        roundedResolution,
+      console.log(
+        `[SPARSE] Resolution: exact=${resolution}, final=${finalResolution}`,
       )
-        ? parseFloat(resolution.toFixed(2))
-        : roundedResolution
 
-      fittedPyramid.origins.push([...pyramid.origins[j]])
+      /**
+       * For TILED_SPARSE overlays at non-matching resolutions:
+       * Calculate where the SEG's origin is in base image pixel coordinates,
+       * then create an extent that positions the SEG correctly.
+       */
+      const refOriginSeq = refBaseLevel.TotalPixelMatrixOriginSequence?.[0]
+      const segOriginSeq = segmentation.TotalPixelMatrixOriginSequence?.[0]
+
+      /** Default to using scaled SEG extent if origins match or are unavailable */
+      let offsetX = 0
+      let offsetY = 0
+
+      if (refOriginSeq && segOriginSeq) {
+        const refOriginX = Number(
+          refOriginSeq.XOffsetInSlideCoordinateSystem || 0,
+        )
+        const refOriginY = Number(
+          refOriginSeq.YOffsetInSlideCoordinateSystem || 0,
+        )
+        const segOriginX = Number(
+          segOriginSeq.XOffsetInSlideCoordinateSystem || 0,
+        )
+        const segOriginY = Number(
+          segOriginSeq.YOffsetInSlideCoordinateSystem || 0,
+        )
+
+        /**
+         * Calculate the physical offset between origins.
+         * Then convert to base image pixel coordinates.
+         */
+        const physicalOffsetX = segOriginX - refOriginX
+        const physicalOffsetY = segOriginY - refOriginY
+
+        /**
+         * Convert physical offset to base image pixels.
+         * Need to account for ImageOrientationSlide.
+         */
+        const orientation = refBaseLevel.ImageOrientationSlide
+        if (orientation) {
+          const rowCosines = orientation.slice(0, 3)
+          const colCosines = orientation.slice(3, 6)
+
+          /**
+           * For standard orientations, the offset in pixels is:
+           * pixelCol = physicalX / (colCosines[0] * spacing[1]) approximately
+           * But this is complex - for now, use simpler approximation
+           */
+          offsetX = physicalOffsetX / refBasePixelSpacing[1]
+          offsetY = physicalOffsetY / refBasePixelSpacing[0]
+
+          /**
+           * Adjust for orientation - common case is [0,-1,0,-1,0,0]
+           * which means col direction is -X and row direction is -Y
+           */
+          if (Math.abs(colCosines[0]) > 0.5) {
+            offsetX = physicalOffsetX / (colCosines[0] * refBasePixelSpacing[1])
+          }
+          if (Math.abs(rowCosines[1]) > 0.5) {
+            offsetY = physicalOffsetY / (rowCosines[1] * refBasePixelSpacing[0])
+          }
+        }
+
+        console.log(
+          '[SPARSE] Origin offset - physical:',
+          { physicalOffsetX, physicalOffsetY },
+          'pixels:',
+          { offsetX, offsetY },
+        )
+      }
+
+      /**
+       * Create extent for the SEG overlay in base image coordinate system.
+       * The SEG covers its own pixel dimensions, scaled by resolution ratio.
+       */
+      const segCols = segmentation.TotalPixelMatrixColumns
+      const segRows = segmentation.TotalPixelMatrixRows
+      const scaledWidth = segCols * resolution
+      const scaledHeight = segRows * resolution
+
+      const extent = [
+        offsetX,
+        -(offsetY + scaledHeight + 1),
+        offsetX + scaledWidth,
+        -(offsetY + 1),
+      ]
+      console.log(
+        '[SPARSE] Calculated extent:',
+        extent,
+        'from SEG size:',
+        { segCols, segRows },
+        'scaled by:',
+        resolution,
+      )
+      fittedPyramid.extent = extent
+
+      /**
+       * For TILED_SPARSE, frames may be positioned at arbitrary pixel locations
+       * within the TotalPixelMatrix, not necessarily at tile boundaries.
+       * We need to calculate the sub-tile offset and adjust the tile grid origin.
+       */
+      let tileOriginOffset = [0, 0]
+      const perframeFuncGroups = segmentation.PerFrameFunctionalGroupsSequence
+      const tileHeight = segmentation.Rows
+      const tileWidth = segmentation.Columns
+
+      console.log(
+        `[SPARSE] Analyzing ${perframeFuncGroups?.length || 0} frames, tile size: ${tileWidth}x${tileHeight}, resolution: ${resolution.toFixed(4)}`,
+      )
+
+      if (perframeFuncGroups && perframeFuncGroups.length > 0) {
+        /** Check all frames to see if they have consistent sub-tile offsets */
+        const subTileOffsets = []
+
+        for (
+          let frameIdx = 0;
+          frameIdx < Math.min(perframeFuncGroups.length, 10);
+          frameIdx++
+        ) {
+          const framePosition =
+            perframeFuncGroups[frameIdx].PlanePositionSlideSequence?.[0]
+          if (framePosition) {
+            const rowPosition = Number(
+              framePosition.RowPositionInTotalImagePixelMatrix,
+            )
+            const colPosition = Number(
+              framePosition.ColumnPositionInTotalImagePixelMatrix,
+            )
+
+            if (!Number.isNaN(rowPosition) && !Number.isNaN(colPosition)) {
+              const tileRowIndex = Math.ceil(rowPosition / tileHeight)
+              const tileColIndex = Math.ceil(colPosition / tileWidth)
+              const tileBoundaryRow = (tileRowIndex - 1) * tileHeight + 1
+              const tileBoundaryCol = (tileColIndex - 1) * tileWidth + 1
+              const subTileRowOffset = rowPosition - tileBoundaryRow
+              const subTileColOffset = colPosition - tileBoundaryCol
+
+              subTileOffsets.push({
+                frameIdx,
+                rowPosition,
+                colPosition,
+                subTileRowOffset,
+                subTileColOffset,
+              })
+
+              console.log(
+                `[SPARSE] Frame ${frameIdx}: pos=(${rowPosition}, ${colPosition}), ` +
+                  `tileIdx=(${tileRowIndex}, ${tileColIndex}), ` +
+                  `subTileOffset=(${subTileRowOffset}, ${subTileColOffset})`,
+              )
+            }
+          }
+        }
+
+        /** Use the first frame's offset to calculate the adjustment */
+        if (subTileOffsets.length > 0) {
+          const firstOffset = subTileOffsets[0]
+          const baseRowOffset = firstOffset.subTileRowOffset * resolution
+          const baseColOffset = firstOffset.subTileColOffset * resolution
+
+          /**
+           * The tile grid origin needs to be adjusted so that when OpenLayers
+           * places a tile at grid position (row, col), the content aligns
+           * with the actual frame position.
+           *
+           * For OpenLayers with Y-down coordinate system:
+           * - Positive x offset shifts tiles to the right
+           * - Negative y offset shifts tiles down (more negative Y)
+           */
+          tileOriginOffset = [baseColOffset, -baseRowOffset]
+
+          console.log(
+            `[SPARSE] Calculated tileOriginOffset: [${tileOriginOffset[0].toFixed(2)}, ${tileOriginOffset[1].toFixed(2)}] ` +
+              `(from subTileOffset=(${firstOffset.subTileRowOffset}, ${firstOffset.subTileColOffset}) * resolution=${resolution.toFixed(4)})`,
+          )
+
+          /** Check if all frames have consistent offsets */
+          const allConsistent = subTileOffsets.every(
+            (o) =>
+              o.subTileRowOffset === firstOffset.subTileRowOffset &&
+              o.subTileColOffset === firstOffset.subTileColOffset,
+          )
+          if (!allConsistent) {
+            console.warn(
+              '[SPARSE] WARNING: Not all frames have the same sub-tile offset! Single origin adjustment may not work for all frames.',
+            )
+          }
+        }
+      }
+
+      /**
+       * Adjust the origin to be consistent with the extent.
+       * The extent top-left is at [offsetX, -(offsetY + 1)], so the origin
+       * should start there, plus the sub-tile offset for frame alignment.
+       *
+       * Note: The origin is where tile (0, 0) would be positioned.
+       * For TILED_SPARSE with frames at arbitrary positions, we need
+       * the origin to align with the extent's coordinate system.
+       */
+      const adjustedOrigin = [
+        offsetX + tileOriginOffset[0],
+        -(offsetY + 1) + tileOriginOffset[1],
+      ]
+
+      console.log(
+        `[SPARSE] Origin adjustment: ` +
+          `extentOffset=(${offsetX.toFixed(1)}, ${offsetY.toFixed(1)}), ` +
+          `pyramidOrigin=[${pyramid.origins[j][0]}, ${pyramid.origins[j][1]}], ` +
+          `adjustedOrigin=[${adjustedOrigin[0].toFixed(1)}, ${adjustedOrigin[1].toFixed(1)}]`,
+      )
+      fittedPyramid.origins.push(adjustedOrigin)
       fittedPyramid.gridSizes.push([...pyramid.gridSizes[j]])
       fittedPyramid.tileSizes.push([...pyramid.tileSizes[j]])
       fittedPyramid.resolutions.push(finalResolution)
       fittedPyramid.pixelSpacings.push([...pyramid.pixelSpacings[j]])
       fittedPyramid.metadata.push(pyramid.metadata[j])
       fittedPyramid.frameMappings.push(pyramid.frameMappings[j])
+      if (pyramid.dimensionOrganizationTypes) {
+        fittedPyramid.dimensionOrganizationTypes.push(
+          pyramid.dimensionOrganizationTypes[j],
+        )
+      }
     }
   } else {
     /**
@@ -618,6 +864,11 @@ function _fitImagePyramid(pyramid, refPyramid) {
         fittedPyramid.pixelSpacings.push([...pyramid.pixelSpacings[j]])
         fittedPyramid.metadata.push(pyramid.metadata[j])
         fittedPyramid.frameMappings.push(pyramid.frameMappings[j])
+        if (pyramid.dimensionOrganizationTypes) {
+          fittedPyramid.dimensionOrganizationTypes.push(
+            pyramid.dimensionOrganizationTypes[j],
+          )
+        }
       }
     }
   }

--- a/src/pyramid.test.js
+++ b/src/pyramid.test.js
@@ -1,7 +1,10 @@
 const testCase1 = require('../test/data/TCGA-LUAD_TCGA-05-4244-01Z-00-DX1.json')
 
 const dmv = require('./dicom-microscopy-viewer.js')
-const { _computeImagePyramid } = require('./pyramid.js')
+const {
+  _computeImagePyramid,
+  _findClosestResolutionIndex,
+} = require('./pyramid.js')
 
 describe('_computeImagePyramid', () => {
   /*
@@ -47,5 +50,28 @@ describe('_computeImagePyramid', () => {
     for (let i = 1; i < pyramid.resolutions.length; i++) {
       expect(pyramid.resolutions[i]).toBeLessThan(pyramid.resolutions[i - 1])
     }
+  })
+})
+
+describe('_findClosestResolutionIndex', () => {
+  /**
+   * Used by `_fitImagePyramid` when a SEG/PM has no matching base levels
+   * (e.g. TILED_SPARSE at spacing ~1.19× base). Click-to-zoom must target the
+   * closest base zoom, not the full 0..n-1 range (slim#371).
+   */
+  const resolutions = [64, 32, 16, 8, 4, 2, 1]
+
+  it('returns the index of an exact match', () => {
+    expect(_findClosestResolutionIndex(resolutions, 8)).toBe(3)
+    expect(_findClosestResolutionIndex(resolutions, 1)).toBe(6)
+  })
+
+  it('maps a non-matching fitted resolution to the closest base zoom', () => {
+    expect(_findClosestResolutionIndex(resolutions, 1.19)).toBe(6)
+    expect(_findClosestResolutionIndex(resolutions, 3.1)).toBe(4)
+  })
+
+  it('returns 0 for an empty resolutions array', () => {
+    expect(_findClosestResolutionIndex([], 1.19)).toBe(0)
   })
 })

--- a/src/pyramid.test.js
+++ b/src/pyramid.test.js
@@ -4,6 +4,7 @@ const dmv = require('./dicom-microscopy-viewer.js')
 const {
   _computeImagePyramid,
   _findClosestResolutionIndex,
+  _fitImagePyramid,
 } = require('./pyramid.js')
 
 describe('_computeImagePyramid', () => {
@@ -73,5 +74,206 @@ describe('_findClosestResolutionIndex', () => {
 
   it('returns 0 for an empty resolutions array', () => {
     expect(_findClosestResolutionIndex([], 1.19)).toBe(0)
+  })
+})
+
+describe('_fitImagePyramid zoom indices', () => {
+  /**
+   * Regression: matching pyramids must keep exact-equality min/max zoom
+   * (standard TILED_FULL SEG/PM). Non-matching must map to closest base
+   * indices instead of defaulting to 0..n-1 (slim#371).
+   *
+   * Uses lightweight pyramid stubs — full DICOM JSON fixtures are covered
+   * by viewer integration tests.
+   */
+  const stubLevel = ({ spacing, resolution, sop = '1.2.3' }) => ({
+    origins: [[0, -1]],
+    resolutions: [resolution],
+    gridSizes: [[4, 4]],
+    tileSizes: [[256, 256]],
+    pixelSpacings: [spacing],
+    extent: [0, -1025, 1024, -1],
+    frameMappings: [{}],
+    metadata: [
+      {
+        SOPInstanceUID: sop,
+        Rows: 256,
+        Columns: 256,
+        TotalPixelMatrixRows: 1024,
+        TotalPixelMatrixColumns: 1024,
+        TotalPixelMatrixOriginSequence: [
+          {
+            XOffsetInSlideCoordinateSystem: 0,
+            YOffsetInSlideCoordinateSystem: 0,
+          },
+        ],
+        ImageOrientationSlide: [0, -1, 0, -1, 0, 0],
+        SharedFunctionalGroupsSequence: [
+          {
+            PixelMeasuresSequence: [
+              {
+                PixelSpacing: spacing,
+              },
+            ],
+          },
+        ],
+        PerFrameFunctionalGroupsSequence: [],
+      },
+    ],
+  })
+
+  it('keeps exact matching min/max zoom for shared pyramid levels', () => {
+    const refPyramid = {
+      extent: [0, -2049, 2048, -1],
+      origins: [
+        [0, -1],
+        [0, -1],
+      ],
+      resolutions: [2, 1],
+      gridSizes: [
+        [4, 4],
+        [8, 8],
+      ],
+      tileSizes: [
+        [256, 256],
+        [256, 256],
+      ],
+      pixelSpacings: [
+        [0.001, 0.001],
+        [0.0005, 0.0005],
+      ],
+      frameMappings: [{}, {}],
+      metadata: [
+        {
+          SOPInstanceUID: 'base.1',
+          Rows: 256,
+          Columns: 256,
+          TotalPixelMatrixRows: 1024,
+          TotalPixelMatrixColumns: 1024,
+          TotalPixelMatrixOriginSequence: [
+            {
+              XOffsetInSlideCoordinateSystem: 0,
+              YOffsetInSlideCoordinateSystem: 0,
+            },
+          ],
+          ImageOrientationSlide: [0, -1, 0, -1, 0, 0],
+        },
+        {
+          SOPInstanceUID: 'base.2',
+          Rows: 256,
+          Columns: 256,
+          TotalPixelMatrixRows: 2048,
+          TotalPixelMatrixColumns: 2048,
+          TotalPixelMatrixOriginSequence: [
+            {
+              XOffsetInSlideCoordinateSystem: 0,
+              YOffsetInSlideCoordinateSystem: 0,
+            },
+          ],
+          ImageOrientationSlide: [0, -1, 0, -1, 0, 0],
+        },
+      ],
+    }
+    const segPyramid = stubLevel({
+      spacing: [0.0005, 0.0005],
+      resolution: 1,
+      sop: 'seg.1',
+    })
+    /** Align SEG origin/spacing with finest base level so matching succeeds */
+    segPyramid.origins = [[0, -1]]
+    segPyramid.metadata[0].TotalPixelMatrixRows = 2048
+    segPyramid.metadata[0].TotalPixelMatrixColumns = 2048
+
+    const [, minZoom, maxZoom, hasMatchingLevels] = _fitImagePyramid(
+      segPyramid,
+      refPyramid,
+    )
+
+    expect(hasMatchingLevels).toBe(true)
+    expect(minZoom).toBe(1)
+    expect(maxZoom).toBe(1)
+  })
+
+  it('maps non-matching fitted resolution to closest base zoom', () => {
+    const refPyramid = {
+      extent: [0, -2049, 2048, -1],
+      origins: [
+        [0, -1],
+        [0, -1],
+      ],
+      resolutions: [2, 1],
+      gridSizes: [
+        [4, 4],
+        [8, 8],
+      ],
+      tileSizes: [
+        [256, 256],
+        [256, 256],
+      ],
+      pixelSpacings: [
+        [0.001, 0.001],
+        [0.0005, 0.0005],
+      ],
+      frameMappings: [{}, {}],
+      metadata: [
+        {
+          SOPInstanceUID: 'base.a',
+          Rows: 256,
+          Columns: 256,
+          TotalPixelMatrixRows: 1024,
+          TotalPixelMatrixColumns: 1024,
+          TotalPixelMatrixOriginSequence: [
+            {
+              XOffsetInSlideCoordinateSystem: 0,
+              YOffsetInSlideCoordinateSystem: 0,
+            },
+          ],
+          ImageOrientationSlide: [0, -1, 0, -1, 0, 0],
+          SharedFunctionalGroupsSequence: [
+            {
+              PixelMeasuresSequence: [{ PixelSpacing: [0.001, 0.001] }],
+            },
+          ],
+        },
+        {
+          SOPInstanceUID: 'base.b',
+          Rows: 256,
+          Columns: 256,
+          TotalPixelMatrixRows: 2048,
+          TotalPixelMatrixColumns: 2048,
+          TotalPixelMatrixOriginSequence: [
+            {
+              XOffsetInSlideCoordinateSystem: 0,
+              YOffsetInSlideCoordinateSystem: 0,
+            },
+          ],
+          ImageOrientationSlide: [0, -1, 0, -1, 0, 0],
+          SharedFunctionalGroupsSequence: [
+            {
+              PixelMeasuresSequence: [{ PixelSpacing: [0.0005, 0.0005] }],
+            },
+          ],
+        },
+      ],
+    }
+    /** Spacing ~1.2× finest base → no exact match */
+    const segPyramid = stubLevel({
+      spacing: [0.0006, 0.0006],
+      resolution: 1.2,
+      sop: 'seg.sparse',
+    })
+
+    const [, minZoom, maxZoom, hasMatchingLevels] = _fitImagePyramid(
+      segPyramid,
+      refPyramid,
+    )
+
+    expect(hasMatchingLevels).toBe(false)
+    expect(minZoom).toBe(maxZoom)
+    expect(minZoom).toBe(
+      _findClosestResolutionIndex(refPyramid.resolutions, 0.0006 / 0.0005),
+    )
+    /** Must not fall back to the full base range 0..n-1 */
+    expect(minZoom).not.toBe(0)
   })
 })

--- a/src/segment.js
+++ b/src/segment.js
@@ -26,6 +26,8 @@ class Segment {
    * Segmentation instances
    * @param {string|undefined} options.paletteColorLookupTableUID - Palette
    * Color Lookup Table UID
+   * @param {boolean} [options.isAbsent=false] - True when the segment is
+   * declared in Segment Sequence but has no frame data to display
    */
   constructor({
     uid,
@@ -39,6 +41,7 @@ class Segment {
     seriesInstanceUID,
     sopInstanceUIDs,
     paletteColorLookupTableUID,
+    isAbsent = false,
   }) {
     this[_attrs] = {}
     if (uid === undefined) {
@@ -93,6 +96,7 @@ class Segment {
     this[_attrs].sopInstanceUIDs = sopInstanceUIDs
 
     this[_attrs].paletteColorLookupTableUID = paletteColorLookupTableUID
+    this[_attrs].isAbsent = Boolean(isAbsent)
 
     Object.freeze(this)
   }
@@ -194,6 +198,19 @@ class Segment {
    */
   get paletteColorLookupTableUID() {
     return this[_attrs].paletteColorLookupTableUID
+  }
+
+  /**
+   * Whether the segment has no frame data to display.
+   *
+   * True when the segment is listed in Segment Sequence but no
+   * Per-Frame Functional Groups (or TILED_FULL tiles) map to it.
+   * Callers should disable visibility toggles and skip zoom-to-segment.
+   *
+   * @type boolean
+   */
+  get isAbsent() {
+    return this[_attrs].isAbsent
   }
 }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5467,20 +5467,6 @@ class VolumeImageViewer {
     const segPixelSpacing = getPixelSpacing(segLevel)
     const coordinateScaleFactor = segPixelSpacing[0] / basePixelSpacing[0]
 
-    console.log(
-      '[SPARSE] Creating segmentation TileGrid with:',
-      '\n  extent:',
-      fittedPyramid.extent,
-      '\n  origins:',
-      fittedPyramid.origins,
-      '\n  resolutions:',
-      fittedPyramid.resolutions,
-      '\n  gridSizes:',
-      fittedPyramid.gridSizes,
-      '\n  tileSizes:',
-      fittedPyramid.tileSizes,
-    )
-
     const tileGrid = new TileGrid({
       extent: fittedPyramid.extent,
       origins: fittedPyramid.origins,
@@ -5744,9 +5730,6 @@ class VolumeImageViewer {
           duration: 500,
           maxZoom: segment.maxZoomLevel,
         })
-        console.info(
-          `Zooming to segment bounding box: [${segment.boundingBox.join(', ')}]`,
-        )
       } else {
         /**
          * No bounding box available (segment has no frames).
@@ -5801,7 +5784,6 @@ class VolumeImageViewer {
         duration: 500,
         maxZoom: segment.maxZoomLevel,
       })
-      console.info(`Zooming to segment "${segmentUID}" bounding box`)
     } else {
       console.warn(`Segment "${segmentUID}" has no bounding box to zoom to`)
     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -715,6 +715,88 @@ function _getColorInterpolationStyleForTileLayer({
   return { color: expression, variables }
 }
 
+/**
+ * Compute the bounding box for a segment from its frame mappings.
+ *
+ * @param {Object} pyramid - The image pyramid containing frame mappings
+ * @param {number} segmentNumber - The segment number to compute bounds for
+ * @param {number} [scaleFactor=1] - Scale factor to transform from segment coordinates to base image coordinates
+ * @returns {number[]|null} The extent [minX, minY, maxX, maxY] in map coordinates, or null if no frames exist
+ * @private
+ */
+function _computeSegmentBoundingBox(pyramid, segmentNumber, scaleFactor = 1) {
+  const channelId = String(segmentNumber)
+  let minTileRow = Infinity
+  let maxTileRow = -Infinity
+  let minTileCol = Infinity
+  let maxTileCol = -Infinity
+  let foundAnyFrame = false
+  let tileRows = 0
+  let tileCols = 0
+
+  /**
+   * Search all pyramid levels for frames belonging to this segment.
+   * Use the finest resolution level (last in array) for tile size.
+   */
+  for (let z = 0; z < pyramid.frameMappings.length; z++) {
+    const frameMapping = pyramid.frameMappings[z]
+    const metadata = pyramid.metadata[z]
+
+    if (!frameMapping || !metadata) continue
+
+    tileRows = metadata.Rows
+    tileCols = metadata.Columns
+
+    for (const key of Object.keys(frameMapping)) {
+      /** Key format is "rowIndex-colIndex-channelIdentifier" */
+      const parts = key.split('-')
+      if (parts.length >= 3 && parts[parts.length - 1] === channelId) {
+        const rowIndex = parseInt(parts[0], 10)
+        const colIndex = parseInt(parts[1], 10)
+
+        minTileRow = Math.min(minTileRow, rowIndex)
+        maxTileRow = Math.max(maxTileRow, rowIndex)
+        minTileCol = Math.min(minTileCol, colIndex)
+        maxTileCol = Math.max(maxTileCol, colIndex)
+        foundAnyFrame = true
+      }
+    }
+
+    /** Only need to check one level since all levels should have same frames */
+    if (foundAnyFrame) break
+  }
+
+  if (!foundAnyFrame) {
+    return null
+  }
+
+  /**
+   * Convert tile indices to pixel coordinates in the segment's coordinate system.
+   * Tile indices are 1-based, so we subtract 1 for 0-based pixel calculation.
+   */
+  const minPixelX = (minTileCol - 1) * tileCols
+  const maxPixelX = maxTileCol * tileCols
+  const minPixelY = (minTileRow - 1) * tileRows
+  const maxPixelY = maxTileRow * tileRows
+
+  /**
+   * Apply scale factor to transform from segment coordinates to base image coordinates.
+   * This is needed when the segment is at a different resolution than the base image.
+   */
+  const scaledMinX = minPixelX * scaleFactor
+  const scaledMaxX = maxPixelX * scaleFactor
+  const scaledMinY = minPixelY * scaleFactor
+  const scaledMaxY = maxPixelY * scaleFactor
+
+  /**
+   * Convert to map coordinates.
+   * In the viewer, Y is inverted: map Y = -(pixel Y + 1)
+   */
+  const extent = [scaledMinX, -(scaledMaxY + 1), scaledMaxX, -(scaledMinY + 1)]
+
+  return extent
+}
+
 const _errorInterceptor = Symbol('errorInterceptor')
 const _retrievedBulkdata = Symbol('retrievedBulkdata')
 const _affine = Symbol.for('affine')
@@ -5373,6 +5455,32 @@ class VolumeImageViewer {
       this[_pyramid],
     )
 
+    /**
+     * Calculate scale factor for coordinate transformation.
+     * This is needed for TILED_SPARSE overlays at different resolutions.
+     * Scale factor = SEG pixel spacing / Base pixel spacing
+     */
+    const refBaseLevel =
+      this[_pyramid].metadata[this[_pyramid].metadata.length - 1]
+    const segLevel = pyramid.metadata[pyramid.metadata.length - 1]
+    const basePixelSpacing = getPixelSpacing(refBaseLevel)
+    const segPixelSpacing = getPixelSpacing(segLevel)
+    const coordinateScaleFactor = segPixelSpacing[0] / basePixelSpacing[0]
+
+    console.log(
+      '[SPARSE] Creating segmentation TileGrid with:',
+      '\n  extent:',
+      fittedPyramid.extent,
+      '\n  origins:',
+      fittedPyramid.origins,
+      '\n  resolutions:',
+      fittedPyramid.resolutions,
+      '\n  gridSizes:',
+      fittedPyramid.gridSizes,
+      '\n  tileSizes:',
+      fittedPyramid.tileSizes,
+    )
+
     const tileGrid = new TileGrid({
       extent: fittedPyramid.extent,
       origins: fittedPyramid.origins,
@@ -5466,6 +5574,11 @@ class VolumeImageViewer {
         },
         hasLoader: false,
         segmentationType: refSegmentation.SegmentationType,
+        boundingBox: _computeSegmentBoundingBox(
+          pyramid,
+          segmentNumber,
+          coordinateScaleFactor,
+        ),
       }
 
       const source = new DataTileSource({
@@ -5619,13 +5732,36 @@ class VolumeImageViewer {
 
     if (shouldZoomIn) {
       const view = this[_map].getView()
-      const currentZoomLevel = view.getZoom()
 
-      if (
-        currentZoomLevel < segment.minZoomLevel ||
-        currentZoomLevel > segment.maxZoomLevel
-      ) {
-        view.animate({ zoom: segment.minZoomLevel })
+      if (segment.boundingBox != null) {
+        /**
+         * Zoom to the segment's bounding box.
+         * This ensures the view shows where the segment data actually exists.
+         */
+        const padding = [50, 50, 50, 50]
+        view.fit(segment.boundingBox, {
+          padding,
+          duration: 500,
+          maxZoom: segment.maxZoomLevel,
+        })
+        console.info(
+          `Zooming to segment bounding box: [${segment.boundingBox.join(', ')}]`,
+        )
+      } else {
+        /**
+         * No bounding box available (segment has no frames).
+         * Just ensure we're at an appropriate zoom level.
+         */
+        const currentZoomLevel = view.getZoom()
+        if (
+          currentZoomLevel < segment.minZoomLevel ||
+          currentZoomLevel > segment.maxZoomLevel
+        ) {
+          view.animate({ zoom: segment.minZoomLevel, duration: 500 })
+        }
+        console.warn(
+          `Segment "${segmentUID}" has no bounding box - it may have no frame data`,
+        )
       }
     }
   }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5551,6 +5551,19 @@ class VolumeImageViewer {
         }),
       }
 
+      /**
+       * A segment is absent when Segment Sequence declares it but the
+       * pyramid has no frames for that channel (common for TILED_SPARSE
+       * where some labels were never found in any patch).
+       */
+      const boundingBox = _computeSegmentBoundingBox(
+        pyramid,
+        segmentNumber,
+        coordinateScaleFactor,
+        fittedOriginOffset,
+      )
+      const isAbsent = boundingBox == null
+
       const segment = {
         segment: new Segment({
           uid: segmentUID,
@@ -5565,6 +5578,7 @@ class VolumeImageViewer {
           sopInstanceUIDs: pyramid.metadata.map((element) => {
             return element.SOPInstanceUID
           }),
+          isAbsent,
         }),
         pyramid,
         style: { ...defaultSegmentStyle },
@@ -5580,12 +5594,8 @@ class VolumeImageViewer {
         },
         hasLoader: false,
         segmentationType: refSegmentation.SegmentationType,
-        boundingBox: _computeSegmentBoundingBox(
-          pyramid,
-          segmentNumber,
-          coordinateScaleFactor,
-          fittedOriginOffset,
-        ),
+        boundingBox,
+        isAbsent,
       }
 
       const source = new DataTileSource({
@@ -5708,6 +5718,13 @@ class VolumeImageViewer {
     }
 
     const segment = this[_segments][segmentUID]
+    if (segment.isAbsent) {
+      console.warn(
+        `Cannot show segment "${segmentUID}": segment is absent ` +
+          '(no frame data).',
+      )
+      return
+    }
     console.info(`show segment ${segmentUID}`)
 
     const container = this[_map].getTargetElement() || this[_container]
@@ -5800,76 +5817,84 @@ class VolumeImageViewer {
     }
 
     const segment = this[_segments][segmentUID]
+    if (segment.isAbsent || segment.boundingBox == null) {
+      console.warn(
+        `Cannot zoom to segment "${segmentUID}": segment is absent ` +
+          '(no frame data / bounding box).',
+      )
+      return
+    }
+
     const view = this[_map].getView()
+    const extent = segment.boundingBox
+    const center = getCenter(extent)
+    const extentWidth = getWidth(extent)
+    const extentHeight = getHeight(extent)
 
-    if (segment.boundingBox != null) {
-      const extent = segment.boundingBox
-      const center = getCenter(extent)
-      const extentWidth = getWidth(extent)
-      const extentHeight = getHeight(extent)
+    /**
+     * Get the viewport size in map coordinates at the target zoom level.
+     * If the segment bounding box is extremely large relative to the viewport
+     * (indicating scattered features like TILED_SPARSE nuclei spread across
+     * a large region), zoom to the fitted/max zoom level centered on the
+     * segment rather than fitting the entire bounding box.
+     *
+     * We use a high threshold (10x) to avoid affecting normal segments like
+     * tumor regions that may span several tiles but should still be shown
+     * in full. Only truly scattered segments (e.g., nuclei across an entire
+     * slide region) will trigger the centered zoom behavior.
+     */
+    const viewportSize = this[_map].getSize()
+    if (!viewportSize) {
+      console.warn('Cannot get map size for zoom calculation')
+      return
+    }
 
+    /**
+     * Prefer the finest fitted zoom (closest base level to SEG resolution).
+     * For matching-pyramid SEGs this is the finest shared level; for
+     * non-matching fitted SEGs it is the closest base index to the fitted
+     * resolution — not the full base range.
+     */
+    const targetZoom = segment.maxZoomLevel
+    const targetResolution = view.getResolutionForZoom(targetZoom)
+    const viewportWidthAtTarget = viewportSize[0] * targetResolution
+    const viewportHeightAtTarget = viewportSize[1] * targetResolution
+
+    /**
+     * Threshold of 10x viewport size - only extremely large/scattered
+     * segments trigger centered zoom behavior. Normal segments (tumor
+     * regions, lesions, etc.) will still fit their bounding box.
+     */
+    const scatterThreshold = 10
+    const isScatteredSegment =
+      extentWidth > viewportWidthAtTarget * scatterThreshold ||
+      extentHeight > viewportHeightAtTarget * scatterThreshold
+
+    if (isScatteredSegment) {
       /**
-       * Get the viewport size in map coordinates at the target zoom level.
-       * If the segment bounding box is extremely large relative to the viewport
-       * (indicating scattered features like TILED_SPARSE nuclei spread across
-       * a large region), zoom to the fitted/max zoom level centered on the
-       * segment rather than fitting the entire bounding box.
-       *
-       * We use a high threshold (10x) to avoid affecting normal segments like
-       * tumor regions that may span several tiles but should still be shown
-       * in full. Only truly scattered segments (e.g., nuclei across an entire
-       * slide region) will trigger the centered zoom behavior.
+       * Bounding box is extremely large (scattered features across a wide
+       * region), zoom to fitted max zoom centered on the segment's bounding
+       * box.
        */
-      const viewportSize = this[_map].getSize()
-      if (!viewportSize) {
-        console.warn('Cannot get map size for zoom calculation')
-        return
-      }
-
-      /** Prefer the finest fitted zoom (closest base level to SEG resolution). */
-      const targetZoom = segment.maxZoomLevel
-      const targetResolution = view.getResolutionForZoom(targetZoom)
-      const viewportWidthAtTarget = viewportSize[0] * targetResolution
-      const viewportHeightAtTarget = viewportSize[1] * targetResolution
-
-      /**
-       * Threshold of 10x viewport size - only extremely large/scattered
-       * segments trigger centered zoom behavior. Normal segments (tumor
-       * regions, lesions, etc.) will still fit their bounding box.
-       */
-      const scatterThreshold = 10
-      const isScatteredSegment =
-        extentWidth > viewportWidthAtTarget * scatterThreshold ||
-        extentHeight > viewportHeightAtTarget * scatterThreshold
-
-      if (isScatteredSegment) {
-        /**
-         * Bounding box is extremely large (scattered features across a wide
-         * region), zoom to fitted max zoom centered on the segment's bounding
-         * box.
-         */
-        view.animate({
-          center: center,
-          zoom: targetZoom,
-          duration: 500,
-        })
-      } else {
-        /** Expand extent slightly for context (scale factor 1.5) */
-        const scale = 1.5
-        const expandedExtent = [
-          center[0] - (extentWidth * scale) / 2,
-          center[1] - (extentHeight * scale) / 2,
-          center[0] + (extentWidth * scale) / 2,
-          center[1] + (extentHeight * scale) / 2,
-        ]
-
-        view.fit(expandedExtent, {
-          duration: 500,
-          maxZoom: segment.maxZoomLevel,
-        })
-      }
+      view.animate({
+        center: center,
+        zoom: targetZoom,
+        duration: 500,
+      })
     } else {
-      console.warn(`Segment "${segmentUID}" has no bounding box to zoom to`)
+      /** Expand extent slightly for context (scale factor 1.5) */
+      const scale = 1.5
+      const expandedExtent = [
+        center[0] - (extentWidth * scale) / 2,
+        center[1] - (extentHeight * scale) / 2,
+        center[0] + (extentWidth * scale) / 2,
+        center[1] + (extentHeight * scale) / 2,
+      ]
+
+      view.fit(expandedExtent, {
+        duration: 500,
+        maxZoom: segment.maxZoomLevel,
+      })
     }
   }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -6888,12 +6888,32 @@ class VolumeImageViewer {
     }
 
     const view = this[_map].getView()
-    const currentZoomLevel = view.getZoom()
+    /**
+     * Prefer pyramid resolution over OL zoom index. With free zoom (Slim),
+     * view zoom ≠ pyramid level; after non-matching fit, min/max collapse to
+     * the closest base index and animate({ zoom }) would jump incorrectly.
+     */
+    const resolutions = this[_pyramid].resolutions
+    const minIndex = mapping.minZoomLevel
+    const maxIndex = mapping.maxZoomLevel
     if (
-      currentZoomLevel < mapping.minZoomLevel ||
-      currentZoomLevel > mapping.maxZoomLevel
+      resolutions != null &&
+      resolutions.length > 0 &&
+      Number.isInteger(minIndex) &&
+      Number.isInteger(maxIndex) &&
+      minIndex >= 0 &&
+      maxIndex < resolutions.length
     ) {
-      view.animate({ zoom: mapping.minZoomLevel })
+      const coarsestResolution = resolutions[minIndex]
+      const finestResolution = resolutions[maxIndex]
+      const currentResolution = view.getResolution()
+      if (
+        currentResolution == null ||
+        currentResolution > coarsestResolution * 1.01 ||
+        currentResolution < finestResolution * 0.99
+      ) {
+        view.animate({ resolution: coarsestResolution })
+      }
     }
 
     mapping.layer.setVisible(true)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5766,25 +5766,28 @@ class VolumeImageViewer {
       if (segment.boundingBox != null) {
         /**
          * Zoom to the segment's bounding box.
-         * This ensures the view shows where the segment data actually exists.
+         * Cap with pyramid resolution (not OL zoom index): Slim and other
+         * hosts often use free zoom (`useTileGridResolutions: false`), where
+         * view zoom ≠ pyramid level index.
          */
         const padding = [50, 50, 50, 50]
         view.fit(segment.boundingBox, {
           padding,
           duration: 500,
-          maxZoom: segment.maxZoomLevel,
+          minResolution: this._getSegmentTargetResolution(segment),
         })
       } else {
         /**
          * No bounding box available (segment has no frames).
          * Just ensure we're at an appropriate zoom level.
          */
-        const currentZoomLevel = view.getZoom()
+        const targetResolution = this._getSegmentTargetResolution(segment)
+        const currentResolution = view.getResolution()
         if (
-          currentZoomLevel < segment.minZoomLevel ||
-          currentZoomLevel > segment.maxZoomLevel
+          currentResolution == null ||
+          currentResolution > targetResolution * 1.01
         ) {
-          view.animate({ zoom: segment.minZoomLevel, duration: 500 })
+          view.animate({ resolution: targetResolution, duration: 500 })
         }
         console.warn(
           `Segment "${segmentUID}" has no bounding box - it may have no frame data`,
@@ -5794,12 +5797,39 @@ class VolumeImageViewer {
   }
 
   /**
+   * Map a segment's preferred pyramid level to a view resolution.
+   *
+   * `minZoomLevel` / `maxZoomLevel` are indices into the base image pyramid
+   * resolutions. With free zoom (no constrained view resolutions), those
+   * indices are not OpenLayers zoom levels — callers must animate/fit by
+   * resolution instead of `zoom` / `maxZoom`.
+   *
+   * @param {Object} segment - Internal segment record
+   * @returns {number} Target map resolution (map units per pixel)
+   * @private
+   */
+  _getSegmentTargetResolution(segment) {
+    const resolutions = this[_pyramid].resolutions
+    const index = segment.maxZoomLevel
+    if (
+      resolutions != null &&
+      resolutions.length > 0 &&
+      Number.isInteger(index) &&
+      index >= 0 &&
+      index < resolutions.length
+    ) {
+      return resolutions[index]
+    }
+    return resolutions[resolutions.length - 1]
+  }
+
+  /**
    * Zoom to a segment's bounding box.
    *
    * For segments with compact bounding boxes, fits the view to show the
    * entire segment with some context. For segments with large bounding boxes
    * (e.g., TILED_SPARSE with scattered features), zooms to the segment's
-   * preferred (fitted) zoom level centered on the bounding box.
+   * preferred (fitted) resolution centered on the bounding box.
    *
    * `minZoomLevel` / `maxZoomLevel` come from `_fitImagePyramid`. When the
    * SEG has no matching base pyramid levels, those values are the closest
@@ -5831,11 +5861,23 @@ class VolumeImageViewer {
     const extentWidth = getWidth(extent)
     const extentHeight = getHeight(extent)
 
+    if (
+      !Number.isFinite(extentWidth) ||
+      !Number.isFinite(extentHeight) ||
+      extentWidth <= 0 ||
+      extentHeight <= 0
+    ) {
+      console.warn(
+        `Cannot zoom to segment "${segmentUID}": invalid bounding box.`,
+      )
+      return
+    }
+
     /**
-     * Get the viewport size in map coordinates at the target zoom level.
+     * Get the viewport size in map coordinates at the target resolution.
      * If the segment bounding box is extremely large relative to the viewport
      * (indicating scattered features like TILED_SPARSE nuclei spread across
-     * a large region), zoom to the fitted/max zoom level centered on the
+     * a large region), zoom to the fitted resolution centered on the
      * segment rather than fitting the entire bounding box.
      *
      * We use a high threshold (10x) to avoid affecting normal segments like
@@ -5850,13 +5892,10 @@ class VolumeImageViewer {
     }
 
     /**
-     * Prefer the finest fitted zoom (closest base level to SEG resolution).
-     * For matching-pyramid SEGs this is the finest shared level; for
-     * non-matching fitted SEGs it is the closest base index to the fitted
-     * resolution — not the full base range.
+     * Prefer the finest fitted pyramid resolution (not OL zoom index).
+     * Free-zoom hosts (Slim) must animate/fit by resolution.
      */
-    const targetZoom = segment.maxZoomLevel
-    const targetResolution = view.getResolutionForZoom(targetZoom)
+    const targetResolution = this._getSegmentTargetResolution(segment)
     const viewportWidthAtTarget = viewportSize[0] * targetResolution
     const viewportHeightAtTarget = viewportSize[1] * targetResolution
 
@@ -5873,12 +5912,12 @@ class VolumeImageViewer {
     if (isScatteredSegment) {
       /**
        * Bounding box is extremely large (scattered features across a wide
-       * region), zoom to fitted max zoom centered on the segment's bounding
+       * region), zoom to fitted resolution centered on the segment's bounding
        * box.
        */
       view.animate({
         center: center,
-        zoom: targetZoom,
+        resolution: targetResolution,
         duration: 500,
       })
     } else {
@@ -5893,7 +5932,7 @@ class VolumeImageViewer {
 
       view.fit(expandedExtent, {
         duration: 500,
-        maxZoom: segment.maxZoomLevel,
+        minResolution: targetResolution,
       })
     }
   }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -721,10 +721,16 @@ function _getColorInterpolationStyleForTileLayer({
  * @param {Object} pyramid - The image pyramid containing frame mappings
  * @param {number} segmentNumber - The segment number to compute bounds for
  * @param {number} [scaleFactor=1] - Scale factor to transform from segment coordinates to base image coordinates
+ * @param {number[]} [pixelOffset=[0, 0]] - Origin offset `[offsetX, offsetY]` in base image pixels (from the fitted pyramid)
  * @returns {number[]|null} The extent [minX, minY, maxX, maxY] in map coordinates, or null if no frames exist
  * @private
  */
-function _computeSegmentBoundingBox(pyramid, segmentNumber, scaleFactor = 1) {
+function _computeSegmentBoundingBox(
+  pyramid,
+  segmentNumber,
+  scaleFactor = 1,
+  pixelOffset = [0, 0],
+) {
   const channelId = String(segmentNumber)
   let minTileRow = Infinity
   let maxTileRow = -Infinity
@@ -789,10 +795,17 @@ function _computeSegmentBoundingBox(pyramid, segmentNumber, scaleFactor = 1) {
   const scaledMaxY = maxPixelY * scaleFactor
 
   /**
-   * Convert to map coordinates.
-   * In the viewer, Y is inverted: map Y = -(pixel Y + 1)
+   * Apply fitted-pyramid origin offset (physical origin between SEG and base),
+   * then convert to map coordinates. Y is inverted: map Y = -(pixel Y + 1).
    */
-  const extent = [scaledMinX, -(scaledMaxY + 1), scaledMaxX, -(scaledMinY + 1)]
+  const offsetX = pixelOffset[0] || 0
+  const offsetY = pixelOffset[1] || 0
+  const extent = [
+    offsetX + scaledMinX,
+    -(offsetY + scaledMaxY + 1),
+    offsetX + scaledMaxX,
+    -(offsetY + scaledMinY + 1),
+  ]
 
   return extent
 }
@@ -5450,10 +5463,8 @@ class VolumeImageViewer {
     )
 
     const pyramid = _computeImagePyramid({ metadata })
-    const [fittedPyramid, minZoomLevel, maxZoomLevel] = _fitImagePyramid(
-      pyramid,
-      this[_pyramid],
-    )
+    const [fittedPyramid, minZoomLevel, maxZoomLevel, hasMatchingLevels] =
+      _fitImagePyramid(pyramid, this[_pyramid])
 
     /**
      * Calculate scale factor for coordinate transformation.
@@ -5466,6 +5477,15 @@ class VolumeImageViewer {
     const basePixelSpacing = getPixelSpacing(refBaseLevel)
     const segPixelSpacing = getPixelSpacing(segLevel)
     const coordinateScaleFactor = segPixelSpacing[0] / basePixelSpacing[0]
+
+    /**
+     * Fitted extent encodes the SEG origin in base pixels:
+     *   [offsetX, -(offsetY + scaledHeight + 1), offsetX + scaledWidth, -(offsetY + 1)]
+     */
+    const fittedOriginOffset = [
+      fittedPyramid.extent[0],
+      -(fittedPyramid.extent[3] + 1),
+    ]
 
     const tileGrid = new TileGrid({
       extent: fittedPyramid.extent,
@@ -5564,6 +5584,7 @@ class VolumeImageViewer {
           pyramid,
           segmentNumber,
           coordinateScaleFactor,
+          fittedOriginOffset,
         ),
       }
 
@@ -5612,8 +5633,14 @@ class VolumeImageViewer {
         }),
         useInterimTilesOnError: false,
         cacheSize: this[_options].tilesCacheSize,
+        /**
+         * Only clamp overlay visibility to matching pyramid levels. For
+         * non-matching (fitted) single-level SEGs, min/max zoom map to the
+         * closest base index for click-to-zoom, but the overlay must stay
+         * visible at all view resolutions.
+         */
         minResolution:
-          this[_mapViewResolutions] === undefined
+          this[_mapViewResolutions] === undefined || !hasMatchingLevels
             ? undefined
             : minZoomLevel > 0
               ? this[_pyramid].resolutions[minZoomLevel]
@@ -5755,7 +5782,12 @@ class VolumeImageViewer {
    * For segments with compact bounding boxes, fits the view to show the
    * entire segment with some context. For segments with large bounding boxes
    * (e.g., TILED_SPARSE with scattered features), zooms to the segment's
-   * max zoom level centered on the bounding box.
+   * preferred (fitted) zoom level centered on the bounding box.
+   *
+   * `minZoomLevel` / `maxZoomLevel` come from `_fitImagePyramid`. When the
+   * SEG has no matching base pyramid levels, those values are the closest
+   * base zoom indices to the fitted resolution — not the full base range —
+   * so click-to-zoom lands on the overlay's native scale (slim#371).
    *
    * @param {string} segmentUID - Unique tracking identifier of a segment
    */
@@ -5780,8 +5812,8 @@ class VolumeImageViewer {
        * Get the viewport size in map coordinates at the target zoom level.
        * If the segment bounding box is extremely large relative to the viewport
        * (indicating scattered features like TILED_SPARSE nuclei spread across
-       * a large region), zoom to the max zoom level centered on the segment
-       * rather than fitting the entire bounding box.
+       * a large region), zoom to the fitted/max zoom level centered on the
+       * segment rather than fitting the entire bounding box.
        *
        * We use a high threshold (10x) to avoid affecting normal segments like
        * tumor regions that may span several tiles but should still be shown
@@ -5794,6 +5826,7 @@ class VolumeImageViewer {
         return
       }
 
+      /** Prefer the finest fitted zoom (closest base level to SEG resolution). */
       const targetZoom = segment.maxZoomLevel
       const targetResolution = view.getResolutionForZoom(targetZoom)
       const viewportWidthAtTarget = viewportSize[0] * targetResolution
@@ -5812,7 +5845,8 @@ class VolumeImageViewer {
       if (isScatteredSegment) {
         /**
          * Bounding box is extremely large (scattered features across a wide
-         * region), zoom to max zoom centered on the segment's bounding box.
+         * region), zoom to fitted max zoom centered on the segment's bounding
+         * box.
          */
         view.animate({
           center: center,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5752,6 +5752,11 @@ class VolumeImageViewer {
   /**
    * Zoom to a segment's bounding box.
    *
+   * For segments with compact bounding boxes, fits the view to show the
+   * entire segment with some context. For segments with large bounding boxes
+   * (e.g., TILED_SPARSE with scattered features), zooms to the segment's
+   * max zoom level centered on the bounding box.
+   *
    * @param {string} segmentUID - Unique tracking identifier of a segment
    */
   zoomToSegment(segmentUID) {
@@ -5768,22 +5773,67 @@ class VolumeImageViewer {
     if (segment.boundingBox != null) {
       const extent = segment.boundingBox
       const center = getCenter(extent)
-      const width = getWidth(extent)
-      const height = getHeight(extent)
+      const extentWidth = getWidth(extent)
+      const extentHeight = getHeight(extent)
 
-      /** Expand extent slightly for context (scale factor 1.5) */
-      const scale = 1.5
-      const expandedExtent = [
-        center[0] - (width * scale) / 2,
-        center[1] - (height * scale) / 2,
-        center[0] + (width * scale) / 2,
-        center[1] + (height * scale) / 2,
-      ]
+      /**
+       * Get the viewport size in map coordinates at the target zoom level.
+       * If the segment bounding box is extremely large relative to the viewport
+       * (indicating scattered features like TILED_SPARSE nuclei spread across
+       * a large region), zoom to the max zoom level centered on the segment
+       * rather than fitting the entire bounding box.
+       *
+       * We use a high threshold (10x) to avoid affecting normal segments like
+       * tumor regions that may span several tiles but should still be shown
+       * in full. Only truly scattered segments (e.g., nuclei across an entire
+       * slide region) will trigger the centered zoom behavior.
+       */
+      const viewportSize = this[_map].getSize()
+      if (!viewportSize) {
+        console.warn('Cannot get map size for zoom calculation')
+        return
+      }
 
-      view.fit(expandedExtent, {
-        duration: 500,
-        maxZoom: segment.maxZoomLevel,
-      })
+      const targetZoom = segment.maxZoomLevel
+      const targetResolution = view.getResolutionForZoom(targetZoom)
+      const viewportWidthAtTarget = viewportSize[0] * targetResolution
+      const viewportHeightAtTarget = viewportSize[1] * targetResolution
+
+      /**
+       * Threshold of 10x viewport size - only extremely large/scattered
+       * segments trigger centered zoom behavior. Normal segments (tumor
+       * regions, lesions, etc.) will still fit their bounding box.
+       */
+      const scatterThreshold = 10
+      const isScatteredSegment =
+        extentWidth > viewportWidthAtTarget * scatterThreshold ||
+        extentHeight > viewportHeightAtTarget * scatterThreshold
+
+      if (isScatteredSegment) {
+        /**
+         * Bounding box is extremely large (scattered features across a wide
+         * region), zoom to max zoom centered on the segment's bounding box.
+         */
+        view.animate({
+          center: center,
+          zoom: targetZoom,
+          duration: 500,
+        })
+      } else {
+        /** Expand extent slightly for context (scale factor 1.5) */
+        const scale = 1.5
+        const expandedExtent = [
+          center[0] - (extentWidth * scale) / 2,
+          center[1] - (extentHeight * scale) / 2,
+          center[0] + (extentWidth * scale) / 2,
+          center[1] + (extentHeight * scale) / 2,
+        ]
+
+        view.fit(expandedExtent, {
+          duration: 500,
+          maxZoom: segment.maxZoomLevel,
+        })
+      }
     } else {
       console.warn(`Segment "${segmentUID}" has no bounding box to zoom to`)
     }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -5767,6 +5767,47 @@ class VolumeImageViewer {
   }
 
   /**
+   * Zoom to a segment's bounding box.
+   *
+   * @param {string} segmentUID - Unique tracking identifier of a segment
+   */
+  zoomToSegment(segmentUID) {
+    if (!(segmentUID in this[_segments])) {
+      console.warn(
+        `Cannot zoom to segment. Could not find segment "${segmentUID}".`,
+      )
+      return
+    }
+
+    const segment = this[_segments][segmentUID]
+    const view = this[_map].getView()
+
+    if (segment.boundingBox != null) {
+      const extent = segment.boundingBox
+      const center = getCenter(extent)
+      const width = getWidth(extent)
+      const height = getHeight(extent)
+
+      /** Expand extent slightly for context (scale factor 1.5) */
+      const scale = 1.5
+      const expandedExtent = [
+        center[0] - (width * scale) / 2,
+        center[1] - (height * scale) / 2,
+        center[0] + (width * scale) / 2,
+        center[1] + (height * scale) / 2,
+      ]
+
+      view.fit(expandedExtent, {
+        duration: 500,
+        maxZoom: segment.maxZoomLevel,
+      })
+      console.info(`Zooming to segment "${segmentUID}" bounding box`)
+    } else {
+      console.warn(`Segment "${segmentUID}" has no bounding box to zoom to`)
+    }
+  }
+
+  /**
    * Hide a segment.
    *
    * @param {string} segmentUID - Unique tracking identifier of a segment


### PR DESCRIPTION
## Summary

Fixes https://github.com/ImagingDataCommons/slim/issues/371

**Paired Slim PR:** https://github.com/ImagingDataCommons/slim/pull/429

This PR fixes alignment issues with TILED_SPARSE DICOM segmentation overlays and adds zoom functionality for segments.

### Background

The issue involves a specific workflow where researchers:
1. Extract individual patches of interest from whole slide images at high detail
2. Rescale those patches to a fixed resolution that doesn't match any level in the base image pyramid
3. Annotate the patches to create segmentation masks
4. Encode the segmentations as DICOM SEG with `TILED_SPARSE` DimensionOrganizationType

Because the segmentation exists at a "virtual" resolution level (one that doesn't match any actual pyramid level), and because most tiles are conceptually missing (only the annotated patches have actual data), the viewer was failing to display these overlays correctly.

### Root Cause

Two issues were causing misalignment:

1. **Resolution rounding error**: The code was using `Math.round(resolution)` to calculate the scale factor between segmentation and base image. For a resolution ratio of ~1.19, this rounded to 1, causing a ~19% scale mismatch.

2. **Sub-tile frame positioning not handled**: TILED_SPARSE frames can be positioned at arbitrary pixel locations within the TotalPixelMatrix (using `RowPositionInTotalImagePixelMatrix` and `ColumnPositionInTotalImagePixelMatrix`), not just at tile boundaries. This wasn't being accounted for in the tile grid origin calculation.

### Solution

**Resolution fix:**
- Changed from `Math.round(resolution)` to `parseFloat(resolution.toFixed(4))` to preserve the precise scale factor

**Sub-tile offset handling:**
- Parse `PerFrameFunctionalGroupsSequence` to get actual frame positions
- Calculate the sub-tile offset: `framePosition - tileBoundary`
- Scale offset by resolution ratio to convert to base image coordinates  
- Adjust tile grid origin to align frames correctly

**Physical coordinate alignment:**
- Calculate physical origin differences using `TotalPixelMatrixOriginSequence`
- Convert physical offsets to pixel coordinates accounting for `ImageOrientationSlide`
- Position the segmentation extent correctly relative to the base image

**Fitted-pyramid click-to-zoom:**
- When SEG has no matching base levels, map `minZoom`/`maxZoom` to the closest base indices of the fitted resolution (not `0..n-1`)
- Keep non-matching overlays visible at all view resolutions
- Offset segment bounding boxes by the fitted origin

**Absent segments:**
- Set `segment.isAbsent` when Segment Sequence lists a channel with no pyramid frames
- `showSegment` / `zoomToSegment` no-op for absent segments

### Code Safety Analysis

**These changes do NOT affect standard segmentation types:**

1. **Segmentations with matching pyramid levels** (the common case) - Go through the unchanged `else` branch in `_fitImagePyramid`

2. **Segmentations at different resolution but same physical origin** - The origin calculation produces the same `[0, -1]` result as before when physical offsets are zero

3. **Segmentations with different physical origins** - These are now correctly positioned (improvement over old behavior which ignored physical position)

The changes specifically target the `matchingLevelIndices.length === 0` code path, which only triggers when the segmentation doesn't match any base pyramid level - exactly the TILED_SPARSE case we're fixing.

### Additional Changes

- **`zoomToSegment(segmentUID)` method**: Zooms to a segment's bounding box (or fitted max zoom for scattered SEGs)
- **Performance optimization**: Empty tile caching to avoid repeated allocations for missing tiles
- **Removed debug logging**: All console.log statements added during development have been removed

## Test Plan

- [x] Unit tests pass
- [x] Manual testing confirms TILED_SPARSE segmentation aligns correctly with base image
- [x] Standard TILED_FULL segmentations continue to work correctly (no regression)
- [x] Zoom-to-segment functionality works when clicking segment labels
- [x] Performance is acceptable when toggling multiple segments
- [ ] Fitted-pyramid zoom targets native overlay scale (PanopTILs)
- [ ] Absent segments exposed via `isAbsent` for Slim UI