### PR TITLE
Make colorspace detection async

### DIFF
--- a/src/observable.js
+++ b/src/observable.js
@@ -1,5 +1,6 @@
 const _value = Symbol('value')
 const _subscribers = Symbol('subscribers')
+const _cleanupFunctions = Symbol('cleanupFunctions')
 
 /**
  * A self-contained, DOM-independent reactive value store.
@@ -25,6 +26,7 @@ class Observable {
   constructor(initialValue) {
     this[_value] = initialValue
     this[_subscribers] = []
+    this[_cleanupFunctions] = []
   }
 
   /**
@@ -85,11 +87,34 @@ class Observable {
   }
 
   /**
+   * Registers a cleanup callback to be called when the observable is cleaned up.
+   *
+   * @param {function(): void} cleanup - The cleanup callback.
+   */
+  addCleanup(cleanup) {
+    if (typeof cleanup !== 'function') {
+      throw new TypeError('Observable.addCleanup: cleanup must be a function')
+    }
+    this[_cleanupFunctions].push(cleanup)
+  }
+
+  /**
+   * Removes registered resources and subscribers.
+   */
+  cleanup() {
+    // Note: Splice is used to immediately delete all elements from the array.
+    for (const cleanup of this[_cleanupFunctions].splice(0)) {
+      cleanup()
+    }
+    this[_subscribers] = []
+  }
+
+  /**
    * Removes all subscribers and resets the stored value to `undefined`.
    * After calling `destroy`, the observable should not be used further.
    */
   destroy() {
-    this[_subscribers] = []
+    this.cleanup()
     this[_value] = undefined
   }
 }

--- a/src/observable.test.js
+++ b/src/observable.test.js
@@ -170,6 +170,53 @@ describe('Observable', () => {
     })
   })
 
+  describe('cleanup', () => {
+    it('runs all registered cleanup callbacks', () => {
+      const obs = new Observable(0)
+      const calls = []
+
+      obs.addCleanup(() => calls.push('first'))
+      obs.addCleanup(() => calls.push('second'))
+
+      obs.cleanup()
+
+      expect(calls).toEqual(['first', 'second'])
+    })
+
+    it('runs cleanup callbacks only once', () => {
+      const obs = new Observable(0)
+      const cleanup = jest.fn()
+      obs.addCleanup(cleanup)
+
+      obs.cleanup()
+      obs.cleanup()
+
+      expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws if the cleanup callback is not a function', () => {
+      const obs = new Observable(0)
+
+      expect(() => obs.addCleanup('not-a-function')).toThrow(TypeError)
+    })
+
+    it('removes subscribers and cancels pending notifications', async () => {
+      const obs = new Observable(0)
+      const calls = []
+      obs.subscribe((value) => calls.push(value))
+
+      obs.setValue(1)
+      obs.cleanup()
+
+      await Promise.resolve()
+
+      obs.setValue(2)
+      await Promise.resolve()
+
+      expect(calls).toEqual([])
+    })
+  })
+
   describe('destroy', () => {
     it('stops all subscribers from receiving notifications', async () => {
       const obs = new Observable(0)

--- a/src/utils.js
+++ b/src/utils.js
@@ -696,8 +696,16 @@ function detectDisplayColorSpace() {
     for (const mediaQuery of [p3MediaQuery, srgbMediaQuery]) {
       if (mediaQuery.addEventListener) {
         mediaQuery.addEventListener('change', updateColorSpace)
+        colorSpace.addCleanup(() =>
+          mediaQuery.removeEventListener('change', updateColorSpace),
+        )
       } else {
-        mediaQuery.addListener?.(updateColorSpace)
+        if (mediaQuery.addListener) {
+          mediaQuery.addListener(updateColorSpace)
+          colorSpace.addCleanup(() =>
+            mediaQuery.removeListener?.(updateColorSpace),
+          )
+        }
       }
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 import { inv, multiply } from 'mathjs'
 import { getPointResolution } from 'ol/proj'
 import { v4 as createUUIDv4, v5 as createUUIDv5 } from 'uuid'
+import Observable from './observable.js'
 
 const _UUID_NAMESPACE = 'c4f09b11-bac0-4f3a-8dc1-9f0046637383'
 
@@ -680,17 +681,27 @@ function throttle(mainFunction, delay) {
  * Detect the display color space.
  * Note: The WebGLRenderingContext only supports sRGB and Display-P3
  * color spaces, Adobe RGB (1998) and ROMM RGB are not supported.
- * @returns {string} 'display-p3' or 'srgb'
+ * @returns {Observable<string>} Observable containing 'display-p3' or 'srgb'
  */
 function detectDisplayColorSpace() {
+  const colorSpace = new Observable('srgb')
   if (typeof window !== 'undefined' && window.matchMedia) {
-    if (window.matchMedia('(color-gamut: p3)').matches) {
-      return 'display-p3'
-    } else if (window.matchMedia('(color-gamut: srgb)').matches) {
-      return 'srgb'
+    const p3MediaQuery = window.matchMedia('(color-gamut: p3)')
+    const srgbMediaQuery = window.matchMedia('(color-gamut: srgb)')
+    const updateColorSpace = () => {
+      colorSpace.setValue(p3MediaQuery.matches ? 'display-p3' : 'srgb')
+    }
+
+    updateColorSpace()
+    for (const mediaQuery of [p3MediaQuery, srgbMediaQuery]) {
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', updateColorSpace)
+      } else {
+        mediaQuery.addListener?.(updateColorSpace)
+      }
     }
   }
-  return 'srgb'
+  return colorSpace
 }
 
 export {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -281,7 +281,7 @@ describe('test detectDisplayColorSpace function', () => {
       dispatchEvent: jest.fn(),
     }))
 
-    expect(utils.detectDisplayColorSpace()).toEqual('display-p3')
+    expect(utils.detectDisplayColorSpace().getValue()).toEqual('display-p3')
   })
 
   it('should fall back to srgb when p3 is not supported', () => {
@@ -297,14 +297,40 @@ describe('test detectDisplayColorSpace function', () => {
       dispatchEvent: jest.fn(),
     }))
 
-    expect(utils.detectDisplayColorSpace()).toEqual('srgb')
+    expect(utils.detectDisplayColorSpace().getValue()).toEqual('srgb')
   })
 
   it('should default to srgb when window.matchMedia is not available', () => {
     // Mock matchMedia to be undefined
     window.matchMedia = undefined
 
-    expect(utils.detectDisplayColorSpace()).toEqual('srgb')
+    expect(utils.detectDisplayColorSpace().getValue()).toEqual('srgb')
+  })
+
+  it('should notify subscribers when the display color space changes', async () => {
+    let p3ChangeListener
+    const p3MediaQuery = {
+      matches: false,
+      addEventListener: jest.fn((event, listener) => {
+        p3ChangeListener = listener
+      }),
+    }
+    window.matchMedia = jest.fn((query) =>
+      query === '(color-gamut: p3)'
+        ? p3MediaQuery
+        : { matches: true, addEventListener: jest.fn() },
+    )
+
+    const colorSpace = utils.detectDisplayColorSpace()
+    const subscriber = jest.fn()
+    colorSpace.subscribe(subscriber)
+
+    p3MediaQuery.matches = true
+    p3ChangeListener()
+    await Promise.resolve()
+
+    expect(subscriber).toHaveBeenCalledWith('display-p3', 'srgb')
+    expect(colorSpace.getValue()).toEqual('display-p3')
   })
 
 })

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -1815,7 +1815,13 @@ class VolumeImageViewer {
     this._setupMapEventListeners()
     this._setupDrawingSourceEventListeners()
     this[_unsubscribeDisplayColorSpace] = this[_iccOutputType].subscribe(() => {
-      this.refreshColorSpace()
+      // Target color space changed
+      // Reconfigure the dataloaders if ICC profiles are enabled
+      if (!this[_isICCProfilesEnabled]) {
+        return
+      }
+
+      this.configureDataLoaders(this[_isICCProfilesEnabled])
     })
   }
 
@@ -2435,96 +2441,57 @@ class VolumeImageViewer {
    */
   toggleICCProfiles() {
     console.debug('toggle ICC profiles:', this[_isICCProfilesEnabled])
+    this.configureDataLoaders(!this[_isICCProfilesEnabled]).then(() => {
+      // Update the toggle if reloading was successful
+      this[_isICCProfilesEnabled] = !this[_isICCProfilesEnabled]
+    })
+  }
+
+  async configureDataLoaders(iccProfilesEnabled) {
     const itemsRequiringDecodersAndTransformers = [
       ...Object.values(this[_opticalPaths]),
       ...Object.values(this[_segments]),
       ...Object.values(this[_mappings]),
     ]
 
-    itemsRequiringDecodersAndTransformers.forEach((item) => {
-      const metadata = item.pyramid.metadata
-      const client = _getClient(
-        this[_clients],
-        Enums.SOPClassUIDs.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE,
-      )
-      _getIccProfiles({
-        metadata,
-        client,
-        onError: (error) => {
-          console.error('Failed to fetch ICC profiles:', error)
-          const customError = new CustomError(
-            errorTypes.VISUALIZATION,
-            'Failed to fetch ICC profiles',
-          )
-          this[_options].errorInterceptor(customError)
-        },
-      }).then((profiles) => {
-        this[_iccProfiles] = profiles
+    // Update the data loaders of all items asynchronously
+    await Promise.all(
+      itemsRequiringDecodersAndTransformers.map(async (item) => {
+        const metadata = item.pyramid.metadata
+        const client = _getClient(
+          this[_clients],
+          Enums.SOPClassUIDs.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE,
+        )
+        this[_iccProfiles] = await _getIccProfiles({
+          metadata,
+          client,
+          onError: (error) => {
+            console.error('Failed to fetch ICC profiles:', error)
+            const customError = new CustomError(
+              errorTypes.VISUALIZATION,
+              'Failed to fetch ICC profiles',
+            )
+            this[_options].errorInterceptor(customError)
+          },
+        })
+
         const source = item.layer.getSource()
         if (!source) {
           return
         }
-        const loaderWithICCProfiles = _createTileLoadFunction({
+
+        const loaderConfig = {
           targetElement: this[_container],
-          iccProfiles: profiles,
-          iccOutputType: this[_iccOutputType].getValue(),
-          ...item.loaderParams,
-        })
-        const loaderWithoutICCProfiles = _createTileLoadFunction({
-          targetElement: this[_container],
-          ...item.loaderParams,
-        })
-        const loader = this[_isICCProfilesEnabled]
-          ? loaderWithICCProfiles
-          : loaderWithoutICCProfiles
-        source.setLoader(loader)
-        source.refresh()
-        item.hasLoader = true
-      })
-    })
+        }
 
-    this[_isICCProfilesEnabled] = !this[_isICCProfilesEnabled]
-  }
-
-  refreshColorSpace() {
-    if (!this[_isICCProfilesEnabled]) {
-      return
-    }
-
-    const itemsRequiringDecodersAndTransformers = [
-      ...Object.values(this[_opticalPaths]),
-      ...Object.values(this[_segments]),
-      ...Object.values(this[_mappings]),
-    ]
-
-    itemsRequiringDecodersAndTransformers.forEach((item) => {
-      const metadata = item.pyramid.metadata
-      const client = _getClient(
-        this[_clients],
-        Enums.SOPClassUIDs.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE,
-      )
-      _getIccProfiles({
-        metadata,
-        client,
-        onError: (error) => {
-          console.error('Failed to fetch ICC profiles:', error)
-          const customError = new CustomError(
-            errorTypes.VISUALIZATION,
-            'Failed to fetch ICC profiles',
-          )
-          this[_options].errorInterceptor(customError)
-        },
-      }).then((profiles) => {
-        this[_iccProfiles] = profiles
-        const source = item.layer.getSource()
-        if (!source) {
-          return
+        // Add ICC profile configuration if enabled
+        if (iccProfilesEnabled) {
+          loaderConfig.iccProfiles = this[_iccProfiles]
+          loaderConfig.iccOutputType = this[_iccOutputType].getValue()
         }
 
         const loader = _createTileLoadFunction({
-          targetElement: this[_container],
-          iccProfiles: profiles,
-          iccOutputType: this[_iccOutputType].getValue(),
+          ...loaderConfig,
           ...item.loaderParams,
         })
 
@@ -2535,18 +2502,18 @@ class VolumeImageViewer {
           bandCount: source.bandCount,
           interpolate: source.getInterpolate(),
         })
+
         replacementSource.setLoader(loader)
+        item.layer.setSource(replacementSource)
+        item.overviewLayer?.setSource(replacementSource)
+        item.hasLoader = true
         if (item.onTileLoadError) {
           replacementSource.on('tileloaderror', item.onTileLoadError)
         }
-        item.layer.setSource(replacementSource)
-        if (item.overviewLayer) {
-          item.overviewLayer.setSource(replacementSource)
-        }
-        item.hasLoader = true
-      })
-    })
+      }),
+    )
 
+    // Force a re-render to let the changes take effect
     this[_map]?.render()
   }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2434,6 +2434,7 @@ class VolumeImageViewer {
   getICCProfiles() {
     return this[_iccProfiles] || []
   }
+
   /**
    * Toggle ICC profiles.
    *
@@ -2441,10 +2442,19 @@ class VolumeImageViewer {
    */
   toggleICCProfiles() {
     console.debug('toggle ICC profiles:', this[_isICCProfilesEnabled])
-    this.configureDataLoaders(!this[_isICCProfilesEnabled]).then(() => {
-      // Update the toggle if reloading was successful
-      this[_isICCProfilesEnabled] = !this[_isICCProfilesEnabled]
-    })
+    this.configureDataLoaders(!this[_isICCProfilesEnabled])
+      .then(() => {
+        // Update the toggle if reloading was successful
+        this[_isICCProfilesEnabled] = !this[_isICCProfilesEnabled]
+      })
+      .catch((error) => {
+        console.error('Failed to toggle ICC profiles:', error)
+        const customError = new CustomError(
+          errorTypes.VISUALIZATION,
+          'Failed to toggle ICC profiles',
+        )
+        this[_options].errorInterceptor(customError)
+      })
   }
 
   async configureDataLoaders(iccProfilesEnabled) {
@@ -2454,47 +2464,51 @@ class VolumeImageViewer {
       ...Object.values(this[_mappings]),
     ]
 
-    // Update the data loaders of all items asynchronously
-    await Promise.all(
-      itemsRequiringDecodersAndTransformers.map(async (item) => {
-        const metadata = item.pyramid.metadata
-        const client = _getClient(
-          this[_clients],
-          Enums.SOPClassUIDs.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE,
-        )
-        this[_iccProfiles] = await _getIccProfiles({
-          metadata,
-          client,
-          onError: (error) => {
-            console.error('Failed to fetch ICC profiles:', error)
-            const customError = new CustomError(
-              errorTypes.VISUALIZATION,
-              'Failed to fetch ICC profiles',
-            )
-            this[_options].errorInterceptor(customError)
-          },
-        })
+    if (itemsRequiringDecodersAndTransformers.length === 0) {
+      return
+    }
 
-        const source = item.layer.getSource()
-        if (!source) {
-          return
-        }
+    const client = _getClient(
+      this[_clients],
+      Enums.SOPClassUIDs.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE,
+    )
 
-        const loaderConfig = {
-          targetElement: this[_container],
-        }
+    // TODO: We could make this async, however, we would need to determine what this[_iccProfiles] should actually contain (it's overwritten every loop instance)
+    for (const item of itemsRequiringDecodersAndTransformers) {
+      this[_iccProfiles] = await _getIccProfiles({
+        metadata: item.pyramid.metadata,
+        client,
+        onError: (error) => {
+          console.error('Failed to fetch ICC profiles:', error)
+          const customError = new CustomError(
+            errorTypes.VISUALIZATION,
+            'Failed to fetch ICC profiles',
+          )
+          this[_options].errorInterceptor(customError)
+        },
+      })
 
-        // Add ICC profile configuration if enabled
-        if (iccProfilesEnabled) {
-          loaderConfig.iccProfiles = this[_iccProfiles]
-          loaderConfig.iccOutputType = this[_iccOutputType].getValue()
-        }
+      const source = item.layer.getSource()
+      if (!source) {
+        return
+      }
 
-        const loader = _createTileLoadFunction({
-          ...loaderConfig,
-          ...item.loaderParams,
-        })
+      const loaderConfig = {
+        targetElement: this[_container],
+      }
 
+      // Add ICC profile configuration if enabled
+      if (iccProfilesEnabled) {
+        loaderConfig.iccProfiles = this[_iccProfiles]
+        loaderConfig.iccOutputType = this[_iccOutputType].getValue()
+      }
+
+      const loader = _createTileLoadFunction({
+        ...loaderConfig,
+        ...item.loaderParams,
+      })
+
+      const createReplacementSource = () => {
         const replacementSource = new DataTileSource({
           tileGrid: source.getTileGrid(),
           projection: source.getProjection(),
@@ -2504,14 +2518,16 @@ class VolumeImageViewer {
         })
 
         replacementSource.setLoader(loader)
-        item.layer.setSource(replacementSource)
-        item.overviewLayer?.setSource(replacementSource)
-        item.hasLoader = true
         if (item.onTileLoadError) {
           replacementSource.on('tileloaderror', item.onTileLoadError)
         }
-      }),
-    )
+        return replacementSource
+      }
+
+      item.layer.setSource(createReplacementSource())
+      item.overviewLayer?.setSource(createReplacementSource())
+      item.hasLoader = true
+    }
 
     // Force a re-render to let the changes take effect
     this[_map]?.render()
@@ -2848,6 +2864,7 @@ class VolumeImageViewer {
    */
   cleanup() {
     console.info('cleanup memory')
+    this[_iccOutputType]?.cleanup?.()
     this[_unsubscribeDisplayColorSpace]?.()
     const itemsRequiringDisposal = [
       ...Object.values(this[_opticalPaths]),
@@ -5504,17 +5521,18 @@ class VolumeImageViewer {
         /** Avoid interpolation for single resolution (avoid blocky pixels) */
         interpolate: this[_segmentationInterpolate],
       })
-      source.on('tileloaderror', (event) => {
+      segment.onTileLoadError = (event) => {
         console.error(
           `error loading tile of segment "${segmentUID}"`,
           event.tile?.error_?.message || event,
         )
         const error = new CustomError(
           errorTypes.VISUALIZATION,
-          `error loading tile of segment "${segmentUID}": ${event.message}`,
+          `error loading tile of segment "${segmentUID}": ${event.tile?.error_?.message || event.message}`,
         )
         this[_options].errorInterceptor(error)
-      })
+      }
+      source.on('tileloaderror', segment.onTileLoadError)
 
       const [windowCenter, windowWidth] = createWindow(
         minStoredValue,
@@ -6505,17 +6523,18 @@ class VolumeImageViewer {
         bandCount: 1,
         interpolate: this[_parametricMapInterpolate],
       })
-      source.on('tileloaderror', (event) => {
+      mapping.onTileLoadError = (event) => {
         console.error(
           `error loading tile of mapping "${mappingUID}"`,
           event.tile?.error_?.message || event,
         )
         const error = new CustomError(
           errorTypes.VISUALIZATION,
-          `error loading tile of mapping "${mappingUID}": ${event.message}`,
+          `error loading tile of mapping "${mappingUID}": ${event.tile?.error_?.message || event.message}`,
         )
         this[_options].errorInterceptor(error)
-      })
+      }
+      source.on('tileloaderror', mapping.onTileLoadError)
 
       mapping.layer = new TileLayer({
         source,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -74,6 +74,7 @@ import {
   groupMonochromeInstances,
   VLWholeSlideMicroscopyImage,
 } from './metadata.js'
+import Observable from './observable.js'
 import { OpticalPath } from './opticalPath.js'
 import {
   _areImagePyramidsEqual,
@@ -758,6 +759,7 @@ const _paletteDisplayGammaCorrectionEnabled = Symbol(
   'paletteDisplayGammaCorrectionEnabled',
 )
 const _derivedLegendCollapsed = Symbol('derivedLegendCollapsed')
+const _unsubscribeDisplayColorSpace = Symbol('unsubscribeDisplayColorSpace')
 
 /**
  * Interactive viewer for DICOM VL Whole Slide Microscopy Image instances
@@ -823,7 +825,7 @@ class VolumeImageViewer {
     this[_clients] = {}
     this[_errorInterceptor] = options.errorInterceptor || ((error) => error)
     this[_isICCProfilesEnabled] = true
-    this[_iccOutputType] = 'srgb'
+    this[_iccOutputType] = new Observable('srgb')
     this[_container] = null
     this[_clients] = {}
     this[_iccProfiles] = []
@@ -1391,7 +1393,7 @@ class VolumeImageViewer {
         opticalPath.layer.on('precompose', (event) => {
           const gl = event.context
           if ('drawingBufferColorSpace' in gl) {
-            gl.drawingBufferColorSpace = this[_iccOutputType]
+            gl.drawingBufferColorSpace = this[_iccOutputType].getValue()
           }
           gl.enable(gl.BLEND)
           gl.blendEquation(gl.FUNC_ADD)
@@ -1420,7 +1422,7 @@ class VolumeImageViewer {
         opticalPath.overviewLayer.on('precompose', (event) => {
           const gl = event.context
           if ('drawingBufferColorSpace' in gl) {
-            gl.drawingBufferColorSpace = this[_iccOutputType]
+            gl.drawingBufferColorSpace = this[_iccOutputType].getValue()
           }
           gl.enable(gl.BLEND)
           gl.blendEquation(gl.FUNC_ADD)
@@ -1472,7 +1474,7 @@ class VolumeImageViewer {
         transition: 0,
         bandCount: 3,
       })
-      source.on('tileloaderror', (event) => {
+      opticalPath.onTileLoadError = (event) => {
         console.error(
           `error loading tile of optical path "${opticalPathIdentifier}"`,
           event.tile?.error_?.message || event,
@@ -1482,7 +1484,8 @@ class VolumeImageViewer {
           `error loading tile of optical path "${opticalPathIdentifier}": ${event.tile?.error_?.message || event.message}`,
         )
         this[_options].errorInterceptor(error)
-      })
+      }
+      source.on('tileloaderror', opticalPath.onTileLoadError)
 
       opticalPath.layer = new TileLayer({
         source,
@@ -1494,7 +1497,7 @@ class VolumeImageViewer {
       opticalPath.layer.on('precompose', (event) => {
         const gl = event.context
         if ('drawingBufferColorSpace' in gl) {
-          gl.drawingBufferColorSpace = this[_iccOutputType]
+          gl.drawingBufferColorSpace = this[_iccOutputType].getValue()
         }
       })
 
@@ -1518,7 +1521,7 @@ class VolumeImageViewer {
       opticalPath.overviewLayer.on('precompose', (event) => {
         const gl = event.context
         if ('drawingBufferColorSpace' in gl) {
-          gl.drawingBufferColorSpace = this[_iccOutputType]
+          gl.drawingBufferColorSpace = this[_iccOutputType].getValue()
         }
       })
 
@@ -1811,6 +1814,9 @@ class VolumeImageViewer {
 
     this._setupMapEventListeners()
     this._setupDrawingSourceEventListeners()
+    this[_unsubscribeDisplayColorSpace] = this[_iccOutputType].subscribe(() => {
+      this.refreshColorSpace()
+    })
   }
 
   /**
@@ -2422,16 +2428,6 @@ class VolumeImageViewer {
   getICCProfiles() {
     return this[_iccProfiles] || []
   }
-
-  /**
-   * Get ICC output type.
-   *
-   * @returns {string} ICC output type
-   */
-  getICCOutputType() {
-    return this[_iccOutputType]
-  }
-
   /**
    * Toggle ICC profiles.
    *
@@ -2471,7 +2467,7 @@ class VolumeImageViewer {
         const loaderWithICCProfiles = _createTileLoadFunction({
           targetElement: this[_container],
           iccProfiles: profiles,
-          iccOutputType: this[_iccOutputType],
+          iccOutputType: this[_iccOutputType].getValue(),
           ...item.loaderParams,
         })
         const loaderWithoutICCProfiles = _createTileLoadFunction({
@@ -2488,6 +2484,70 @@ class VolumeImageViewer {
     })
 
     this[_isICCProfilesEnabled] = !this[_isICCProfilesEnabled]
+  }
+
+  refreshColorSpace() {
+    if (!this[_isICCProfilesEnabled]) {
+      return
+    }
+
+    const itemsRequiringDecodersAndTransformers = [
+      ...Object.values(this[_opticalPaths]),
+      ...Object.values(this[_segments]),
+      ...Object.values(this[_mappings]),
+    ]
+
+    itemsRequiringDecodersAndTransformers.forEach((item) => {
+      const metadata = item.pyramid.metadata
+      const client = _getClient(
+        this[_clients],
+        Enums.SOPClassUIDs.VL_WHOLE_SLIDE_MICROSCOPY_IMAGE,
+      )
+      _getIccProfiles({
+        metadata,
+        client,
+        onError: (error) => {
+          console.error('Failed to fetch ICC profiles:', error)
+          const customError = new CustomError(
+            errorTypes.VISUALIZATION,
+            'Failed to fetch ICC profiles',
+          )
+          this[_options].errorInterceptor(customError)
+        },
+      }).then((profiles) => {
+        this[_iccProfiles] = profiles
+        const source = item.layer.getSource()
+        if (!source) {
+          return
+        }
+
+        const loader = _createTileLoadFunction({
+          targetElement: this[_container],
+          iccProfiles: profiles,
+          iccOutputType: this[_iccOutputType].getValue(),
+          ...item.loaderParams,
+        })
+
+        const replacementSource = new DataTileSource({
+          tileGrid: source.getTileGrid(),
+          projection: source.getProjection(),
+          wrapX: source.getWrapX(),
+          bandCount: source.bandCount,
+          interpolate: source.getInterpolate(),
+        })
+        replacementSource.setLoader(loader)
+        if (item.onTileLoadError) {
+          replacementSource.on('tileloaderror', item.onTileLoadError)
+        }
+        item.layer.setSource(replacementSource)
+        if (item.overviewLayer) {
+          item.overviewLayer.setSource(replacementSource)
+        }
+        item.hasLoader = true
+      })
+    })
+
+    this[_map]?.render()
   }
 
   /**
@@ -2742,7 +2802,7 @@ class VolumeImageViewer {
         const loader = _createTileLoadFunction({
           targetElement: container,
           iccProfiles: profiles,
-          iccOutputType: this[_iccOutputType],
+          iccOutputType: this[_iccOutputType].getValue(),
           ...opticalPath.loaderParams,
         })
         const source = opticalPath.layer.getSource()
@@ -2821,6 +2881,7 @@ class VolumeImageViewer {
    */
   cleanup() {
     console.info('cleanup memory')
+    this[_unsubscribeDisplayColorSpace]?.()
     const itemsRequiringDisposal = [
       ...Object.values(this[_opticalPaths]),
       ...Object.values(this[_segments]),
@@ -2924,7 +2985,7 @@ class VolumeImageViewer {
           this[_isICCProfilesEnabled] && profiles.length > 0 ? profiles : null,
         iccOutputType:
           this[_isICCProfilesEnabled] && profiles.length > 0
-            ? this[_iccOutputType]
+            ? this[_iccOutputType].getValue()
             : undefined,
         ...item.loaderParams,
       })

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -2427,6 +2427,15 @@ class VolumeImageViewer {
   }
 
   /**
+   * Get ICC output type.
+   *
+   * @returns {string} ICC output type
+   */
+  getICCOutputType() {
+    return this[_iccOutputType].getValue()
+  }
+
+  /**
    * Get ICC profiles.
    *
    * @returns {any[]} ICC profiles

--- a/src/viewer.test.js
+++ b/src/viewer.test.js
@@ -16,6 +16,19 @@ window.ResizeObserver = window.ResizeObserver || jest.fn().mockImplementation(()
   unobserve: jest.fn()
 }))
 
+describe('viewer ICC API', () => {
+  it('exposes the active ICC output type', () => {
+    const viewer = new dmv.viewer.VolumeImageViewer({
+      client: {},
+      metadata: [new dmv.metadata.VLWholeSlideMicroscopyImage({
+        metadata: testCase1.images[0]
+      })]
+    })
+
+    expect(viewer.getICCOutputType()).toBe('srgb')
+  })
+})
+
 const testCases = [
   {
     name: 'TCGA-LUAD_TCGA-05-4244-01Z-00-DX1',


### PR DESCRIPTION
Colorspace adaptation was already provided in #235. However, as noted in #239, this was inherently limited as it only considered the colorspace when loading. If the colorspace changed afterward (e.g. by moving the viewer from one monitor to another), it would not update the viewer. This PR introduces changes such that it does react to such changes.

It makes use of the observable introduced in #260. The colorspace is emitted as an observable that changes value depending on the `matchmedia` query. The viewer is subscribed to this values and reconfigures the datatile loaders if such a change were to occur.

I have also implemented some small refactoring in the viewer file. More specifically, I have seperated the reload logic in the `toggleICCProfiles` function and reused it for when the colorspace changes.